### PR TITLE
Fixes iOS 7 Rotation Crash

### DIFF
--- a/Pod/Classes/ios/NYTPhotosOverlayView.m
+++ b/Pod/Classes/ios/NYTPhotosOverlayView.m
@@ -41,14 +41,14 @@
 }
 
 - (void)layoutSubviews {
-    [super layoutSubviews];
-    
     // The navigation bar has a different intrinsic content size upon rotation, so we must update to that new size.
     // Do it without animation to more closely match the behavior in `UINavigationController`
     [UIView performWithoutAnimation:^{
         [self.navigationBar invalidateIntrinsicContentSize];
         [self.navigationBar layoutIfNeeded];
     }];
+    
+    [super layoutSubviews];
 }
 
 #pragma mark - NYTPhotosOverlayView


### PR DESCRIPTION
I don’t know why this fixes it, and I also don’t know why this crash was happening in the first place (some sort of auto layout timing issue, apparently), but this is now resolved.

Closes #13
