### PR TITLE
Fixes iPhone 6 Plus Zooming Bug

### DIFF
--- a/Pod/Classes/ios/NYTPhotoViewController.m
+++ b/Pod/Classes/ios/NYTPhotoViewController.m
@@ -158,4 +158,16 @@ NSString * const NYTPhotoViewControllerPhotoImageUpdatedNotification = @"NYTPhot
     return self.scalingImageView.imageView;
 }
 
+- (void)scrollViewWillBeginZooming:(UIScrollView *)scrollView withView:(UIView *)view {
+    scrollView.panGestureRecognizer.enabled = YES;
+}
+
+- (void)scrollViewDidEndZooming:(UIScrollView *)scrollView withView:(UIView *)view atScale:(CGFloat)scale {
+    // There is a bug, especially prevalent on iPhone 6 Plus, that causes zooming to render all other gesture recognizers ineffective.
+    // This bug is fixed by disabling the pan gesture recognizer of the scroll view when it is not needed.
+    if (scrollView.zoomScale == scrollView.minimumZoomScale) {
+        scrollView.panGestureRecognizer.enabled = NO;
+    }
+}
+
 @end


### PR DESCRIPTION
It appears that somehow, the panGestureRecognizer on the scrollview is
interfering with every other gesture recognizer in some cases after
zooming. Its state is Possible at that point, so it shouldn’t be, but
disabling it after zooming and re-enabling it before zooming fixes the
bug while keeping the same behavior. Unfortunately this seems to be
another “I’m not quite sure why this fixes it” workaround, but at least
this fixes it.

Fixes #5
