### PR TITLE
Allow the lazy adding of more photos to the Data Source.

### DIFF
--- a/Example/NYTPhotoViewer/NYTViewController.m
+++ b/Example/NYTPhotoViewer/NYTViewController.m
@@ -71,6 +71,36 @@ static const NSUInteger NYTViewControllerNoReferenceViewPhotoIndex = 4;
     return photos;
 }
 
++ (NSArray *)moreTestPhotos {
+    NSMutableArray *photos = [NSMutableArray array];
+    
+    for (int i = 0; i < 5; i++) {
+        NYTExamplePhoto *photo = [[NYTExamplePhoto alloc] init];
+        
+        photo.image = [UIImage imageNamed:@"NYTimesBuilding"];
+        if (i == NYTViewControllerCustomEverythingPhotoIndex || i == NYTViewControllerDefaultLoadingSpinnerPhotoIndex) {
+            photo.image = nil;
+        }
+        
+        if (i == NYTViewControllerCustomEverythingPhotoIndex) {
+            photo.placeholderImage = [UIImage imageNamed:@"NYTimesBuildingPlaceholder"];
+        }
+        
+        photo.attributedCaptionTitle = [[NSAttributedString alloc] initWithString:@(i + 6).stringValue attributes:@{NSForegroundColorAttributeName: [UIColor whiteColor]}];
+        photo.attributedCaptionSummary = [[NSAttributedString alloc] initWithString:@"summary" attributes:@{NSForegroundColorAttributeName: [UIColor grayColor]}];
+        photo.attributedCaptionCredit = [[NSAttributedString alloc] initWithString:@"credit" attributes:@{NSForegroundColorAttributeName: [UIColor darkGrayColor]}];
+        [photos addObject:photo];
+    }
+    
+    return photos;
+}
+
+-(void)loadMorePhotos:(NYTPhotosViewController*)photosViewController {
+    NSArray* morePhotos = [[self class] moreTestPhotos];
+    self.photos = [self.photos arrayByAddingObjectsFromArray:morePhotos];
+    [photosViewController addMorePhotosToDataSource:morePhotos];
+}
+
 #pragma mark - NYTPhotosViewControllerDelegate
 
 - (UIView *)photosViewController:(NYTPhotosViewController *)photosViewController referenceViewForPhoto:(id <NYTPhoto>)photo {
@@ -114,6 +144,10 @@ static const NSUInteger NYTViewControllerNoReferenceViewPhotoIndex = 4;
 
 - (void)photosViewController:(NYTPhotosViewController *)photosViewController didDisplayPhoto:(id <NYTPhoto>)photo atIndex:(NSUInteger)photoIndex {
     NSLog(@"Did Display Photo: %@ identifier: %lu", photo, (unsigned long)photoIndex);
+    // This simulates the adding of more images into the data source
+    if ([photo isEqual:self.photos[NYTViewControllerDefaultLoadingSpinnerPhotoIndex]] && self.photos.count == 5) {
+        [self loadMorePhotos:photosViewController];
+    }
 }
 
 - (void)photosViewController:(NYTPhotosViewController *)photosViewController actionCompletedWithActivityType:(NSString *)activityType {

--- a/Pod/Classes/ios/NYTPhotosDataSource.m
+++ b/Pod/Classes/ios/NYTPhotosDataSource.m
@@ -34,6 +34,10 @@
     return self;
 }
 
+- (void)addMorePhotos:(NSArray *)photos {
+    self.photos = [self.photos arrayByAddingObjectsFromArray:photos];
+}
+
 #pragma mark - NSFastEnumeration
 
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(__unsafe_unretained id [])buffer count:(NSUInteger)length {

--- a/Pod/Classes/ios/NYTPhotosViewController.h
+++ b/Pod/Classes/ios/NYTPhotosViewController.h
@@ -94,6 +94,13 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
  */
 - (void)updateImageForPhoto:(id <NYTPhoto>)photo;
 
+/**
+ *  Add more photos to the existing photos array.
+ *
+ *  @param photos An array of objects conforming to the `NYTPhoto` protocol.
+ */
+-(void)addMorePhotosToDataSource:(NSArray*)photos;
+
 @end
 
 /**

--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -161,6 +161,11 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtinImageInsets = {3, 0,
     return self;
 }
 
+-(void)addMorePhotosToDataSource:(NSArray*)photos {
+    [self.dataSource addMorePhotos:photos];
+    [self updateOverlayInformation];
+}
+
 - (void)setupPageViewControllerWithInitialPhoto:(id <NYTPhoto>)initialPhoto {
     self.pageViewController = [[UIPageViewController alloc] initWithTransitionStyle:UIPageViewControllerTransitionStyleScroll navigationOrientation:UIPageViewControllerNavigationOrientationHorizontal options:@{UIPageViewControllerOptionInterPageSpacingKey: @(NYTPhotosViewControllerInterPhotoSpacing)}];
     

--- a/Pod/Classes/ios/Protocols/NYTPhotosViewControllerDataSource.h
+++ b/Pod/Classes/ios/Protocols/NYTPhotosViewControllerDataSource.h
@@ -57,4 +57,12 @@
  */
 - (id <NYTPhoto>)objectAtIndexedSubscript:(NSUInteger)photoIndex;
 
+/**
+ *  Add more photos to the data source array.
+ *
+ *  @param photos An array of objects conforming to the `NYTPhoto` protocol to add to the existing photos array.
+ *
+ */
+- (void)addMorePhotos:(NSArray *)photos;
+
 @end


### PR DESCRIPTION
This allows the appending of more photo objects to the end of the data source allowing for pagination of content.

The use cases for something like this are pretty simple. Services like Instagram/Pinterest allow the loading of 25 or so images at once. These 25 images can be loaded into the PhotoViewer but once you get to the last image instead of forcing the user to exit the PhotoViewer it would be great if we could just fetch more images and add them to the data source. It's great for a site that has "infinite" content. I've updated the example to show off the feature.

I'm sure I'm not quite following the style. Please let me know any changes I might need to make to get this accepted. I'll add some unit tests once I get some initial feedback. 

Thanks