### PR TITLE
Adds Objective-C bridging header info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ NYTPhotoViewer draws feature inspiration from Facebook and Tweetbot's image view
 
 ## Swift
 
-NYTPhotoViewer is written in Objective-C but is intended to be fully interoperable with Swift. If you experience any interoperability difficulties, please open an issue or pull request and we will work to resolve it quickly.
+NYTPhotoViewer is written in Objective-C but is intended to be fully interoperable with Swift. You'll need include an [Objective-C bridging header](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html) like [this one](Example/NYTPhotoViewer-Swift/NYTPhotoViewer-Swift-Bridging-Header.h) from the sample Swift project. If you experience any interoperability difficulties, please open an issue or pull request and we will work to resolve it quickly.
 
 ## TODO
 


### PR DESCRIPTION
For developers new to Swift and/or CocoaPods, I think it would be helpful to have a reminder that they'll need an Objective-C bridging header to use NYTPhotoViewer in their Swift project. My addition includes links to Apple's explanation and to the example Swift app's bridging header for reference.