### PR TITLE
Rename …didDisplayPhoto… to …didNavigateToPhoto…

### DIFF
--- a/Example/NYTPhotoViewer-Swift/ViewController.swift
+++ b/Example/NYTPhotoViewer-Swift/ViewController.swift
@@ -101,8 +101,8 @@ class ViewController: UIViewController, NYTPhotosViewControllerDelegate {
         return nil
     }
     
-    func photosViewController(photosViewController: NYTPhotosViewController!, didDisplayPhoto photo: NYTPhoto!, atIndex photoIndex: UInt) {
-        println("Did Display Photo: \(photo) identifier: \(photoIndex)")
+    func photosViewController(photosViewController: NYTPhotosViewController!, didNavigateToPhoto photo: NYTPhoto!, atIndex photoIndex: UInt) {
+        println("Did Navigate To Photo: \(photo) identifier: \(photoIndex)")
     }
     
     func photosViewController(photosViewController: NYTPhotosViewController!, actionCompletedWithActivityType activityType: String!) {

--- a/Example/NYTPhotoViewer/NYTViewController.m
+++ b/Example/NYTPhotoViewer/NYTViewController.m
@@ -112,8 +112,8 @@ static const NSUInteger NYTViewControllerNoReferenceViewPhotoIndex = 4;
     return nil;
 }
 
-- (void)photosViewController:(NYTPhotosViewController *)photosViewController didDisplayPhoto:(id <NYTPhoto>)photo atIndex:(NSUInteger)photoIndex {
-    NSLog(@"Did Display Photo: %@ identifier: %lu", photo, (unsigned long)photoIndex);
+- (void)photosViewController:(NYTPhotosViewController *)photosViewController didNavigateToPhoto:(id <NYTPhoto>)photo atIndex:(NSUInteger)photoIndex {
+    NSLog(@"Did Navigate To Photo: %@ identifier: %lu", photo, (unsigned long)photoIndex);
 }
 
 - (void)photosViewController:(NYTPhotosViewController *)photosViewController actionCompletedWithActivityType:(NSString *)activityType {

--- a/Pod/Classes/ios/NYTPhotosViewController.h
+++ b/Pod/Classes/ios/NYTPhotosViewController.h
@@ -14,7 +14,7 @@
 @protocol NYTPhotosViewControllerDelegate;
 
 // All notifications will have the `NYTPhotosViewController` instance set as the object.
-extern NSString * const NYTPhotosViewControllerDidDisplayPhotoNotification;
+extern NSString * const NYTPhotosViewControllerDidNavigateToPhotoNotification;
 extern NSString * const NYTPhotosViewControllerWillDismissNotification;
 extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 
@@ -110,7 +110,7 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
  *  @param photo                The photo object that was just displayed.
  *  @param photoIndex           The index of the photo that was just displayed.
  */
-- (void)photosViewController:(NYTPhotosViewController *)photosViewController didDisplayPhoto:(id <NYTPhoto>)photo atIndex:(NSUInteger)photoIndex;
+- (void)photosViewController:(NYTPhotosViewController *)photosViewController didNavigateToPhoto:(id <NYTPhoto>)photo atIndex:(NSUInteger)photoIndex;
 
 /**
  *  Called immediately before the photos view controller is about to start dismissal. This will be the beginning of the interactive panning to dismiss, if it is enabled and performed.

--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -16,7 +16,7 @@
 #import "NYTPhotosOverlayView.h"
 #import "NYTPhotoCaptionView.h"
 
-NSString * const NYTPhotosViewControllerDidDisplayPhotoNotification = @"NYTPhotosViewControllerDidDisplayPhotoNotification";
+NSString * const NYTPhotosViewControllerDidNavigateToPhotoNotification = @"NYTPhotosViewControllerDidNavigateToPhotoNotification";
 NSString * const NYTPhotosViewControllerWillDismissNotification = @"NYTPhotosViewControllerWillDismissNotification";
 NSString * const NYTPhotosViewControllerDidDismissNotification = @"NYTPhotosViewControllerDidDismissNotification";
 
@@ -371,12 +371,12 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtinImageInsets = {3, 0,
     return nil;
 }
 
-- (void)didDisplayPhoto:(id <NYTPhoto>)photo {
-    if ([self.delegate respondsToSelector:@selector(photosViewController:didDisplayPhoto:atIndex:)]) {
-        [self.delegate photosViewController:self didDisplayPhoto:photo atIndex:[self.dataSource indexOfPhoto:photo]];
+- (void)didNavigateToPhoto:(id <NYTPhoto>)photo {
+    if ([self.delegate respondsToSelector:@selector(photosViewController:didNavigateToPhoto:atIndex:)]) {
+        [self.delegate photosViewController:self didNavigateToPhoto:photo atIndex:[self.dataSource indexOfPhoto:photo]];
     }
     
-    [[NSNotificationCenter defaultCenter] postNotificationName:NYTPhotosViewControllerDidDisplayPhotoNotification object:self];
+    [[NSNotificationCenter defaultCenter] postNotificationName:NYTPhotosViewControllerDidNavigateToPhotoNotification object:self];
 }
 
 - (id <NYTPhoto>)currentlyDisplayedPhoto {
@@ -439,7 +439,7 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtinImageInsets = {3, 0,
         [self updateOverlayInformation];
         
         UIViewController <NYTPhotoContainer> *photoViewController = pageViewController.viewControllers.firstObject;
-        [self didDisplayPhoto:photoViewController.photo];
+        [self didNavigateToPhoto:photoViewController.photo];
     }
 }
 


### PR DESCRIPTION
This more closely reflects that this delegate method/notification is tightly tied to user interactions.

I'm taking the viewpoint here that #42 is a naming "bug", not a behavior bug as such, since the method's docs say:

> Called when a new photo is displayed through a swipe gesture.

closes #42