### PR TITLE
Allow setting multiple bar button items for a side

### DIFF
--- a/Example/Tests/NYTPhotosViewControllerTests.m
+++ b/Example/Tests/NYTPhotosViewControllerTests.m
@@ -87,6 +87,17 @@
     XCTAssertNil(photosViewController.leftBarButtonItem);
 }
 
+- (void)testLeftBarButtonItemsArePopulatedAfterInitialization {
+    NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:[self newTestPhotos]];
+    XCTAssertNotNil(photosViewController.leftBarButtonItems);
+}
+
+- (void)testLeftBarButtonItemsAreNilAfterSettingToNil {
+    NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:[self newTestPhotos]];
+    photosViewController.leftBarButtonItems = nil;
+    XCTAssertNil(photosViewController.leftBarButtonItems);
+}
+
 - (void)testRightBarButtonItemIsPopulatedAfterInitialization {
     NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:[self newTestPhotos]];
     XCTAssertNotNil(photosViewController.rightBarButtonItem);
@@ -96,6 +107,17 @@
     NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:[self newTestPhotos]];
     photosViewController.rightBarButtonItem = nil;
     XCTAssertNil(photosViewController.rightBarButtonItem);
+}
+
+- (void)testRightBarButtonItemsArePopulatedAfterInitialization {
+    NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:[self newTestPhotos]];
+    XCTAssertNotNil(photosViewController.rightBarButtonItems);
+}
+
+- (void)testRightBarButtonItemsAreNilAfterSettingToNil {
+    NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:[self newTestPhotos]];
+    photosViewController.rightBarButtonItems = nil;
+    XCTAssertNil(photosViewController.rightBarButtonItems);
 }
 
 - (void)testConvenienceInitializerAcceptsNil {

--- a/Pod/Classes/ios/NYTPhotosOverlayView.h
+++ b/Pod/Classes/ios/NYTPhotosOverlayView.h
@@ -34,9 +34,19 @@
 @property (nonatomic) UIBarButtonItem *leftBarButtonItem;
 
 /**
+ *  The bar button items appearing at the top left of the overlay.
+ */
+@property (nonatomic) NSArray *leftBarButtonItems;
+
+/**
  *  The bar button item appearing at the top right of the overlay.
  */
 @property (nonatomic) UIBarButtonItem *rightBarButtonItem;
+
+/**
+ *  The bar button items appearing at the top right of the overlay.
+ */
+@property (nonatomic) NSArray *rightBarButtonItems;
 
 /**
  *  A view representing the caption for the photo, which will be set to full width and locked to the bottom. Can be any `UIView` object, but is expected to respond to `intrinsicContentSize` appropriately to calculate height.

--- a/Pod/Classes/ios/NYTPhotosOverlayView.h
+++ b/Pod/Classes/ios/NYTPhotosOverlayView.h
@@ -36,7 +36,7 @@
 /**
  *  The bar button items appearing at the top left of the overlay.
  */
-@property (nonatomic) NSArray *leftBarButtonItems;
+@property (nonatomic, copy) NSArray *leftBarButtonItems;
 
 /**
  *  The bar button item appearing at the top right of the overlay.
@@ -46,7 +46,7 @@
 /**
  *  The bar button items appearing at the top right of the overlay.
  */
-@property (nonatomic) NSArray *rightBarButtonItems;
+@property (nonatomic, copy) NSArray *rightBarButtonItems;
 
 /**
  *  A view representing the caption for the photo, which will be set to full width and locked to the bottom. Can be any `UIView` object, but is expected to respond to `intrinsicContentSize` appropriately to calculate height.

--- a/Pod/Classes/ios/NYTPhotosOverlayView.m
+++ b/Pod/Classes/ios/NYTPhotosOverlayView.m
@@ -116,7 +116,7 @@
 }
 
 - (NSArray *)rightBarButtonItems {
-    return self.rightBarButtonItems;
+    return self.navigationItem.rightBarButtonItems;
 }
 
 - (void)setRightBarButtonItems:(NSArray *)rightBarButtonItems {

--- a/Pod/Classes/ios/NYTPhotosOverlayView.m
+++ b/Pod/Classes/ios/NYTPhotosOverlayView.m
@@ -99,12 +99,28 @@
     [self.navigationItem setLeftBarButtonItem:leftBarButtonItem animated:NO];
 }
 
+- (NSArray *)leftBarButtonItems {
+    return self.navigationItem.leftBarButtonItems;
+}
+
+- (void)setLeftBarButtonItems:(NSArray *)leftBarButtonItems {
+    [self.navigationItem setLeftBarButtonItems:leftBarButtonItems animated:NO];
+}
+
 - (UIBarButtonItem *)rightBarButtonItem {
     return self.navigationItem.rightBarButtonItem;
 }
 
 - (void)setRightBarButtonItem:(UIBarButtonItem *)rightBarButtonItem {
     [self.navigationItem setRightBarButtonItem:rightBarButtonItem];
+}
+
+- (NSArray *)rightBarButtonItems {
+    return self.rightBarButtonItems;
+}
+
+- (void)setRightBarButtonItems:(NSArray *)rightBarButtonItems {
+    [self.navigationItem setRightBarButtonItems:rightBarButtonItems animated:NO];
 }
 
 - (NSString *)title {

--- a/Pod/Classes/ios/NYTPhotosOverlayView.m
+++ b/Pod/Classes/ios/NYTPhotosOverlayView.m
@@ -112,7 +112,7 @@
 }
 
 - (void)setRightBarButtonItem:(UIBarButtonItem *)rightBarButtonItem {
-    [self.navigationItem setRightBarButtonItem:rightBarButtonItem];
+    [self.navigationItem setRightBarButtonItem:rightBarButtonItem animated:NO];
 }
 
 - (NSArray *)rightBarButtonItems {

--- a/Pod/Classes/ios/NYTPhotosViewController.h
+++ b/Pod/Classes/ios/NYTPhotosViewController.h
@@ -51,9 +51,19 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 @property (nonatomic) UIBarButtonItem *leftBarButtonItem;
 
 /**
+ *  The left bar button items overlaying the photo.
+ */
+@property (nonatomic) NSArray *leftBarButtonItems;
+
+/**
  *  The right bar button item overlaying the photo.
  */
 @property (nonatomic) UIBarButtonItem *rightBarButtonItem;
+
+/**
+ *  The right bar button items overlaying the photo.
+ */
+@property (nonatomic) NSArray *rightBarButtonItems;
 
 /**
  *  The object that acts as the delegate of the `NYTPhotosViewController`.

--- a/Pod/Classes/ios/NYTPhotosViewController.h
+++ b/Pod/Classes/ios/NYTPhotosViewController.h
@@ -53,7 +53,7 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 /**
  *  The left bar button items overlaying the photo.
  */
-@property (nonatomic) NSArray *leftBarButtonItems;
+@property (nonatomic, copy) NSArray *leftBarButtonItems;
 
 /**
  *  The right bar button item overlaying the photo.
@@ -63,7 +63,7 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 /**
  *  The right bar button items overlaying the photo.
  */
-@property (nonatomic) NSArray *rightBarButtonItems;
+@property (nonatomic, copy) NSArray *rightBarButtonItems;
 
 /**
  *  The object that acts as the delegate of the `NYTPhotosViewController`.

--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -252,12 +252,28 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtinImageInsets = {3, 0,
     self.overlayView.leftBarButtonItem = leftBarButtonItem;
 }
 
+- (NSArray *)leftBarButtonItems {
+    return self.overlayView.leftBarButtonItems;
+}
+
+- (void)setLeftBarButtonItems:(NSArray *)leftBarButtonItems {
+    self.overlayView.leftBarButtonItems = leftBarButtonItems;
+}
+
 - (UIBarButtonItem *)rightBarButtonItem {
     return self.overlayView.rightBarButtonItem;
 }
 
 - (void)setRightBarButtonItem:(UIBarButtonItem *)rightBarButtonItem {
     self.overlayView.rightBarButtonItem = rightBarButtonItem;
+}
+
+- (NSArray *)rightBarButtonItems {
+    return self.overlayView.rightBarButtonItems;
+}
+
+- (void)setRightBarButtonItems:(NSArray *)rightBarButtonItems {
+    self.overlayView.rightBarButtonItems = rightBarButtonItems;
 }
 
 - (void)displayPhoto:(id <NYTPhoto>)photo animated:(BOOL)animated {


### PR DESCRIPTION
Adds support for setting `rightBarButtonItems` and `leftBarButtonItems` on `NYTPhotosViewController`.