### PR TITLE
Ensure nav bar is translucent and has no tint color

### DIFF
--- a/Pod/Classes/ios/NYTPhotosOverlayView.m
+++ b/Pod/Classes/ios/NYTPhotosOverlayView.m
@@ -59,6 +59,8 @@
     
     // Make navigation bar background fully transparent.
     self.navigationBar.backgroundColor = [UIColor clearColor];
+    self.navigationBar.barTintColor = nil;
+    self.navigationBar.translucent = YES;
     self.navigationBar.shadowImage = [[UIImage alloc] init];
     [self.navigationBar setBackgroundImage:[[UIImage alloc] init] forBarMetrics:UIBarMetricsDefault];
     


### PR DESCRIPTION
This is a simple addition to the “Make navigation bar fully transparent” logic already present in `NYTPhotosOverlayView`.

This addresses the navigation bar coloring issue revealed in https://github.com/NYTimes/NYTPhotoViewer/issues/55 , while still allowing users to customize the bar’s tint color and title text attributes via `UIAppearance`.

closes #55