### PR TITLE
Carthage support

### DIFF
--- a/Example/Pods/NYTPhotoViewer/Info.plist
+++ b/Example/Pods/NYTPhotoViewer/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.nytimes.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Example/Pods/NYTPhotoViewer/NYTPhotoViewer.h
+++ b/Example/Pods/NYTPhotoViewer/NYTPhotoViewer.h
@@ -8,12 +8,15 @@
 
 #import <UIKit/UIKit.h>
 
-//! Project version number for NYTPhotoViewer.
+// Project version number for NYTPhotoViewer.
 FOUNDATION_EXPORT double NYTPhotoViewerVersionNumber;
 
-//! Project version string for NYTPhotoViewer.
+// Project version string for NYTPhotoViewer.
 FOUNDATION_EXPORT const unsigned char NYTPhotoViewerVersionString[];
 
-// In this header, you should import all the public headers of your framework using statements like #import <NYTPhotoViewer/PublicHeader.h>
+// Public Headers
+#import <NYTPhotoViewer/NYTPhotosViewController.h>
+#import <NYTPhotoViewer/NYTPhoto.h>
+#import <NYTPhotoViewer/NYTPhotosOverlayView.h>
 
 

--- a/Example/Pods/NYTPhotoViewer/NYTPhotoViewer.h
+++ b/Example/Pods/NYTPhotoViewer/NYTPhotoViewer.h
@@ -1,0 +1,19 @@
+//
+//  NYTPhotoViewer.h
+//  NYTPhotoViewer
+//
+//  Created by Selsky, Michael on 7/15/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for NYTPhotoViewer.
+FOUNDATION_EXPORT double NYTPhotoViewerVersionNumber;
+
+//! Project version string for NYTPhotoViewer.
+FOUNDATION_EXPORT const unsigned char NYTPhotoViewerVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <NYTPhotoViewer/PublicHeader.h>
+
+

--- a/Example/Pods/NYTPhotoViewerTests/Info.plist
+++ b/Example/Pods/NYTPhotoViewerTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.nytimes.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Example/Pods/NYTPhotoViewerTests/NYTPhotoViewerTests.m
+++ b/Example/Pods/NYTPhotoViewerTests/NYTPhotoViewerTests.m
@@ -1,0 +1,40 @@
+//
+//  NYTPhotoViewerTests.m
+//  NYTPhotoViewerTests
+//
+//  Created by Selsky, Michael on 7/15/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+@interface NYTPhotoViewerTests : XCTestCase
+
+@end
+
+@implementation NYTPhotoViewerTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    XCTAssert(YES, @"Pass");
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,6918 +1,2506 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>015E0414AD24281005E5750C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>856456FA1A25692FEFC3FE28</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0164B49DEBF3FD09112BAF54</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F262EA2711B86BFF08D5DA96</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0173576ECF18C2B5B84DA883</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMInvocationExpectation.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMInvocationExpectation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>024111B35564B48AE0023AA9</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>Pods-Tests-OCMock-dummy.m</string>
-			<key>path</key>
-			<string>../Pods-Tests-OCMock/Pods-Tests-OCMock-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0447139662D4FCA4E4612E05</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>6400B340CB182C73CFF3DF39</string>
-			<key>buildPhases</key>
-			<array>
-				<string>3AA9A0E8AB197C15D58851E0</string>
-				<string>7EC47F014DF1D58DA8A1DE1E</string>
-				<string>1334361CABA6075E465C7832</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-Tests-NYTPhotoViewer</string>
-			<key>productName</key>
-			<string>Pods-Tests-NYTPhotoViewer</string>
-			<key>productReference</key>
-			<string>8B0ACC9B5708AD621EE5F694</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>04D5496729A0A1C3E445CCC5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8647301F5C968345D6C65BB3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>04F6115BDEC2C660AD6CEEFC</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>66D75152ED32E28D2FCE0ABE</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>05066F08A4081B2ADC64BFD6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B2926136463FFA4168502AA1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>056829D68A120794CCC55FB1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E0A98A7C6AB18D4103E0D87A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>06DA2E7E2D69F82C0A3DA20C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B9D0611732608546131C68AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>07BAB14A5F32DDF1574F2E99</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMIndirectReturnValueProvider.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMIndirectReturnValueProvider.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>09DE7D921811F6AD29841E02</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>36A2A63B1279C7FA8CDC9145</string>
-			<key>buildPhases</key>
-			<array>
-				<string>7C79097821A783E5E40B9721</string>
-				<string>0B7EC604A48FA1C304C0F7CC</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>3A2C5BC40053F03AB7B173E8</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-Swift</string>
-			<key>productName</key>
-			<string>Pods-NYTPhotoViewer-Swift</string>
-			<key>productReference</key>
-			<string>D68D0582B96DB4EDB28B7091</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>0AAA1B247A4A215F7A5907E3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMInvocationMatcher.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMInvocationMatcher.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0B77D3608D09516179FFEDC8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1C15D35E2817745B63904821</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B7EC604A48FA1C304C0F7CC</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F39AA576F184D8F21C72C46A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0CBCEC4163FB3ADE88A24B80</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EB760647CD2C6D6AF095ECD2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0E763D8CB6064F5D1EFF7599</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4233DAABFADA2023EB350D79</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>0F5F94B5A5F9332D4C8A32C9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B2926136463FFA4168502AA1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>0F7D347C6001BA07836F5F26</key>
-		<dict>
-			<key>fileRef</key>
-			<string>46A58C3669B50A2A63A8C185</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>108E73A754727909F32E6567</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>DB3F5DC7DE66FB7274E6FB52</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>5D82D542EF99743A8B00FCE3</string>
-			<key>remoteInfo</key>
-			<string>Pods-NYTPhotoViewer-NYTPhotoViewer</string>
-		</dict>
-		<key>11852500FC148A8C2C2CCBD8</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>CB9CD201886329065C717498</string>
-				<string>9D87D675530D9E1778566F6E</string>
-				<string>2CAB01BCB2E5807A82F681E7</string>
-				<string>4375A6EB96FD307D003D6671</string>
-				<string>DF8B2633864CE2EE3E36A1EA</string>
-				<string>7F67EE3634297DF862DA26A1</string>
-				<string>F6E67ADB8E8582FDA08A8CBC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-NYTPhotoViewer-SwiftTests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>118F763BC48FEFB7DFA68BF4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5D8AC5A109BD394BDE891454</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>11D73809917EC52B050827A3</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>12143D2710B60903918956F7</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>7F67EE3634297DF862DA26A1</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>12CF97F49B80D0A051FE1DB0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4AA001EFA3696F3A3ECC1C5A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>130B84B5FC7EDFBA3CF03BD8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCProtocolMockObject.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCProtocolMockObject.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1334361CABA6075E465C7832</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>623099A9AF2218F7FF4A697D</string>
-				<string>E21038FD1FE8F1F406CD098B</string>
-				<string>E5F55694026E98ECD9866856</string>
-				<string>70B6FBBC064CC361AB24C0DA</string>
-				<string>70548ECADB5332269E65AF4C</string>
-				<string>AE3D542786E8E1FF3ADACDE1</string>
-				<string>CB6E4EEDCB390C75488510AF</string>
-				<string>2ABC4C2AE43F6DAD3A642F57</string>
-				<string>E48EDDF4E40CB5C5ECA925BB</string>
-				<string>B55134BD22538F5C7D0AACBD</string>
-				<string>6B1C3F40818CBFA16DF95C09</string>
-				<string>E7B376F0E4E7313B48C9B5FD</string>
-				<string>BDB99FA97F7D612B728DBA1B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>139760EB2F3134E3C8A0510C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E9ACDC7D73AD65931322460C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>14C54B648E45B84FB7ADF9D4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>38E5FA1FF570E28DB4310AFF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>151D006F83A16AB3332DB9CC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E0A98A7C6AB18D4103E0D87A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>152A783F03F3584D6CF20251</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F262EA2711B86BFF08D5DA96</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>161E063BBEF3983A7CCF5C34</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>6D9AEF14DBBDA0549E60E96B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>1629E9E9F8042A2096E475B3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTPhoto.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/Protocols/NYTPhoto.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>16DB23E61ADCB20BC55D5D13</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E2D401B06064CBCBE38FFEF4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>16FAD106A2022C3575D8A3AB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-Private.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>183BB060A9ADD0F503B6B2DA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A2AA39193DA6E68F7B97B3A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>18E7BE82797F36BC7315A524</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>E2E4B5C18DCD84D83B675BEF</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>1944CBEDD7EB3F42ABB7035D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMLocation.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMLocation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>19E8A25A23F1C3B97D1B7CD2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>85B981625089E45E1C42CDE4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1A1DE934D733864D4FEEA162</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0173576ECF18C2B5B84DA883</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>1A2EFE1FDE8C273E41FBFCF5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMExceptionReturnValueProvider.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMExceptionReturnValueProvider.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1A5CE29D7708C2092B5F0082</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1944CBEDD7EB3F42ABB7035D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1B46B16FEBC59A4373810420</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>name</key>
-			<string>Podfile</string>
-			<key>path</key>
-			<string>../Podfile</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.ruby</string>
-		</dict>
-		<key>1B53F2FDEF2057318516A931</key>
-		<dict>
-			<key>fileRef</key>
-			<string>87264381DE7CA6CDF3B56575</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1B588B1D79BF7E420074A990</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1944CBEDD7EB3F42ABB7035D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1C15D35E2817745B63904821</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMExpectationRecorder.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMExpectationRecorder.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1D424E9C9915DD35D0596789</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>9B9C54F6E71DF765B769FF6A</string>
-				<string>323B0BCDA6BE5B1ACBCE77AD</string>
-				<string>4D84B0B1828FF9F17EAE72CF</string>
-				<string>3B0D1B05A7A7796A3CB8ED8F</string>
-				<string>C0433EC9D69288656B8A48D0</string>
-				<string>B44CD330DF715C17F797AA32</string>
-				<string>12CF97F49B80D0A051FE1DB0</string>
-				<string>04D5496729A0A1C3E445CCC5</string>
-				<string>F2A7FC568E8088E471D860EE</string>
-				<string>E3BC1B85323AEDDC9FF2FEA2</string>
-				<string>43399EC15351453AE666AECD</string>
-				<string>689FDA306464A152F43FD1F5</string>
-				<string>3772E7EEE6AB6D00D9F331AB</string>
-				<string>BED3EC187AD227769E074EF8</string>
-				<string>1A1DE934D733864D4FEEA162</string>
-				<string>46E6EFF02357FC93AF696272</string>
-				<string>D8CDD718588A07F65EFC97E3</string>
-				<string>118F763BC48FEFB7DFA68BF4</string>
-				<string>3DB3A1DF322DB3431EA27904</string>
-				<string>9231A601A6094B3BBBB3C1B1</string>
-				<string>25CD1295ABE755C4EA757857</string>
-				<string>780B3D1D92E1C2E92E6C1B6B</string>
-				<string>7E16BF7E80E66C9BAA600481</string>
-				<string>BCF5CF2871A2C6A8BE39E35E</string>
-				<string>8F204A9D76A8F45D856BE530</string>
-				<string>601C21199EE2C1DFA1BCB15C</string>
-				<string>738FD3CA96D7B232D196DF3D</string>
-				<string>3D17549A57BFCE5295C87035</string>
-				<string>B337DC4CDE59F58D6651F43D</string>
-				<string>0F5F94B5A5F9332D4C8A32C9</string>
-				<string>A4CFAA11A09B96994A21D71B</string>
-				<string>BC70C00E99E3001779951F4F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>1DA147F57555614CEA3BA0A2</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>C921BC00C737DACBEE8A1920</string>
-				<string>E39A56283839D595EFECFD90</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>1E35AE8BC3084101DDD5EE82</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9F58613E0A68B64D461E3280</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1E38B48D281A26A00772C5A7</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>909E4A4842ED3B4B3B96CB32</string>
-				<string>6FF81625A83435CF70264B05</string>
-				<string>35DB72DE358DA5D2122E1B97</string>
-				<string>420283FDC853B11367189E39</string>
-				<string>B3B96ABE1A56CDFBB87DED83</string>
-				<string>3D37504764B63A760E2F7301</string>
-				<string>574D9F0AFA4EF8C714F0444E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Resources</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1FE1180B890870E37CBC1D98</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-dummy.m</string>
-			<key>path</key>
-			<string>../Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2104855B84EF13FE632EC212</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>DF9B79E0887A8BA249670C1B</string>
-			<key>buildPhases</key>
-			<array>
-				<string>454140A94EADE7E64927003D</string>
-				<string>4F8314F6055C7954A72B9B51</string>
-				<string>DD996922D0E95E131F95FF1D</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-OCMock</string>
-			<key>productName</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-OCMock</string>
-			<key>productReference</key>
-			<string>CF7C82773CF45E8ABC34D9BC</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>2176793C28BC562FDAE85D3F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>85B981625089E45E1C42CDE4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>21A88F51F216B0659EB3B76A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D3585DE44F744998B63E2F8E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>22048393DB660082285AF393</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>22A1B39DABC21B6183F22CCB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FA3488EC2BDD028C8EB901C0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>23EB7844D274BDFC2579DE6D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-NYTPhotoViewer</string>
-			<key>target</key>
-			<string>5D82D542EF99743A8B00FCE3</string>
-			<key>targetProxy</key>
-			<string>108E73A754727909F32E6567</string>
-		</dict>
-		<key>25009C60EF8844370FDAB21D</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>ACD68F5FDE643665CB9CBD6A</string>
-				<string>3496B1C10897E3B078A2373F</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2561273CB0CA8D9EA96CD557</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8C98F7877C29008627A2D842</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2569F5D65FEFD9942A27325B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMInvocationExpectation.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMInvocationExpectation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A6643BB2363320A15111E8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9DD26D85E326E913CEE025D8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25CD1295ABE755C4EA757857</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CABBA1BAA3054F876B0C8F01</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>2666B9448C8F921C33BDE958</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>438A1D6371FE2E2DFF76093A</string>
-				<string>C4DD9FFBE917BC0D311424FB</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>26DCE245D3925CEB3A8D0FDB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2739CDA5AB001D7AEFEF9734</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2739CDA5AB001D7AEFEF9734</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMConstraint.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMConstraint.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>278F689B521DD0D500FE4F99</key>
-		<dict>
-			<key>fileRef</key>
-			<string>45FB9190CA97B941207A4630</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>292D2375F2BD26E146CDD68D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EFA58414A5B2F1CBFC1BECAC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>299B3FFF8FBAB1C3DBCE9236</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer</string>
-			<key>target</key>
-			<string>DACEF04843F4D3AAB41E45B9</string>
-			<key>targetProxy</key>
-			<string>F5BB7526AE1EB62A063D4BB7</string>
-		</dict>
-		<key>2A0999B262595827E16E7A01</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E2D401B06064CBCBE38FFEF4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2A1225DA14A462FFEF175AB9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9F58613E0A68B64D461E3280</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2A66465343511DE9BFA03B77</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>3669B7BC097736BFF008062A</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-NYTPhotoViewer-SwiftTests-OCMock/Pods-NYTPhotoViewer-SwiftTests-OCMock-prefix.pch</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>2AB8C29105D31E289D65839B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>856456FA1A25692FEFC3FE28</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2ABC4C2AE43F6DAD3A642F57</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9075BF902932F4D3B5717B4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2B251A189EC557DDDDDA469E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>87EB1BF6CEA3F1873E4FFA50</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2C05312A1C90F8175B932164</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B9164895990534371A09C187</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2CAB01BCB2E5807A82F681E7</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2CC43C113F8A24E48629AC04</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B12F9AC1F97C4FE18FA0DD03</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2D126C1BB9864B0106EE5884</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>DB3F5DC7DE66FB7274E6FB52</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>0447139662D4FCA4E4612E05</string>
-			<key>remoteInfo</key>
-			<string>Pods-Tests-NYTPhotoViewer</string>
-		</dict>
-		<key>2D934C00AA62DB623AA053F1</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>12143D2710B60903918956F7</string>
-				<string>4E428710ECC26D09F7A781A1</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2DDA1EE2FA4741E1C1A57FAB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMBoxedReturnValueProvider.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMBoxedReturnValueProvider.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2DE06652D777E39D9A720FDD</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B25294FB0CF98C5B8D595A88</string>
-				<string>3669B7BC097736BFF008062A</string>
-				<string>D3585DE44F744998B63E2F8E</string>
-				<string>B0144A696A1552A965AE5DA3</string>
-				<string>6478BC6DA1216C5C7E8AB64D</string>
-				<string>D111BD4C163B390AEAF136CB</string>
-				<string>024111B35564B48AE0023AA9</string>
-				<string>7E67C1CC845E11FBFD6A0365</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>../Target Support Files/Pods-NYTPhotoViewer-SwiftTests-OCMock</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2F54BB8FA3B465875CA7D6F7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CA18D29B4A53538648260D21</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2F8AA59CA858EB5DA740B810</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C3238309106D63A91FE528C9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2FCC37CD4A39646933819732</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1C15D35E2817745B63904821</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>300D825A591949CAB22D43DF</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>1B46B16FEBC59A4373810420</string>
-				<string>7378F61C8B0BBFBE180039FB</string>
-				<string>F9D571D2B40CA5A4BF7C7E69</string>
-				<string>D2C3D477134FE14E09FC534B</string>
-				<string>7C0F5C2FCCF6271836A3C232</string>
-				<string>69FDB42127BB90AD54DC6372</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>307DC766F062DA6F22E0A8C2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMBlockCaller.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMBlockCaller.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>323B0BCDA6BE5B1ACBCE77AD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E26846BA9A7F6C234C6AFD85</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>32C7B0E6AF799371FE62B0D5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>33DC27FA73F298AF8E69D7AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>32CD52FD28A787B9FE09E9F4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BEF933B04E5D228A7A18ADDA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3340CF0CEFCDE830FB2E1835</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>3669B7BC097736BFF008062A</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-NYTPhotoViewer-SwiftTests-OCMock/Pods-NYTPhotoViewer-SwiftTests-OCMock-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>33DB338CD9DE1D0398777F16</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-Tests-NYTPhotoViewer-Private.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-Tests-NYTPhotoViewer/Pods-Tests-NYTPhotoViewer-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>33DC27FA73F298AF8E69D7AB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NYTPhotoCaptionView.m</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotoCaptionView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3496B1C10897E3B078A2373F</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>86B43563820BACECDECDBA14</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-NYTPhotoViewer-NYTPhotoViewer/Pods-NYTPhotoViewer-NYTPhotoViewer-prefix.pch</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>34B5CAE55D0AED1F4718B537</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NSNotificationCenter+OCMAdditions.m</string>
-			<key>path</key>
-			<string>Source/OCMock/NSNotificationCenter+OCMAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>35DB72DE358DA5D2122E1B97</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>NYTPhotoViewerCloseButtonX@3x.png</string>
-			<key>path</key>
-			<string>Pod/Assets/ios/NYTPhotoViewerCloseButtonX@3x.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3669B7BC097736BFF008062A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-OCMock-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>36A2A63B1279C7FA8CDC9145</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>A6576F5C17D55F184B65EB3A</string>
-				<string>04F6115BDEC2C660AD6CEEFC</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>36B833681C4F076BF56FCEBB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>71BC5A9D64F89FE7331C73A3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>36C743ADC61B5F76231EE2BC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D714BC42AFE98071E83FB55A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>36D74CC47D031BBCFE491FE9</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>C9BB0C33DC6D2674A2650FDA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-prefix.pch</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>3713D32BDA852095EA2A73DE</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMStubRecorder.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMStubRecorder.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3772E7EEE6AB6D00D9F331AB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9846BBCE91D248C6CBDC83C1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>37A004E5CFC5AA9A094FD1C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>45FB9190CA97B941207A4630</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>37D61A65EE3B2675B96E4513</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4F62A02EEC12B031041E9587</string>
-				<string>52C049C4964CFC4996FCDFD9</string>
-				<string>22048393DB660082285AF393</string>
-				<string>F4419E858FEA7948D6AE7CFF</string>
-				<string>FDDAB3E5CB605CC4BA09C1AF</string>
-				<string>E2E4B5C18DCD84D83B675BEF</string>
-				<string>38622758EBC4096408358F2A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-NYTPhotoViewer</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>37F8EDFD997F8B953C6B679A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>44800019A7D1F62A409C02AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>38622758EBC4096408358F2A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>38E5FA1FF570E28DB4310AFF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMock.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMock.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>39870B1D6DB0C778CBF6D749</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A2AA39193DA6E68F7B97B3A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3A2C5BC40053F03AB7B173E8</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-Swift-NYTPhotoViewer</string>
-			<key>target</key>
-			<string>85E8BD93A66999131D97D401</string>
-			<key>targetProxy</key>
-			<string>648B76D2318B3F724FE5AFAE</string>
-		</dict>
-		<key>3A344E6D9333FED65A6300C8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CABBA1BAA3054F876B0C8F01</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>3A3E3E8BD2CCF57F7617CC42</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>8229F2538A10468699323314</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>3AA9A0E8AB197C15D58851E0</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2A1225DA14A462FFEF175AB9</string>
-				<string>E884CCF2E609A2DF4B799FA1</string>
-				<string>056829D68A120794CCC55FB1</string>
-				<string>DD68A2A3D11BE1C6A3C0B1C3</string>
-				<string>2A0999B262595827E16E7A01</string>
-				<string>2561273CB0CA8D9EA96CD557</string>
-				<string>36C743ADC61B5F76231EE2BC</string>
-				<string>278F689B521DD0D500FE4F99</string>
-				<string>4D59AED6FC23CA17EA99640F</string>
-				<string>BABDAC7DF5EC609B14B5E411</string>
-				<string>F7EF061A03591B3255B1B664</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>3B0D1B05A7A7796A3CB8ED8F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>751F2F2940E6C6148A62FAC6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>3B934FCE1F8716091A32FE81</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-Tests.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>3CC92C10E7DBA6CBF22A489F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A7885EBD8438F61F0BBF5DEE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3D17549A57BFCE5295C87035</key>
-		<dict>
-			<key>fileRef</key>
-			<string>49E0C917D1519C6A9446AD9E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>3D37504764B63A760E2F7301</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>NYTPhotoViewerCloseButtonXLandscape@3x.png</string>
-			<key>path</key>
-			<string>Pod/Assets/ios/NYTPhotoViewerCloseButtonXLandscape@3x.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3DB3A1DF322DB3431EA27904</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68C7BA95CF440E9D0687A898</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>3EA0E04E44A11259FD882560</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>1E35AE8BC3084101DDD5EE82</string>
-				<string>32C7B0E6AF799371FE62B0D5</string>
-				<string>151D006F83A16AB3332DB9CC</string>
-				<string>D28B95ECC09DA0CE5B579F77</string>
-				<string>16DB23E61ADCB20BC55D5D13</string>
-				<string>F824173726541D181A9D00F3</string>
-				<string>BD575CDF7A4663127252C464</string>
-				<string>37A004E5CFC5AA9A094FD1C5</string>
-				<string>9E635BC1289151E5254E4293</string>
-				<string>909C6DB1829CB8D53D6B5BE9</string>
-				<string>F13A62CD6E12E5F145564A34</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>3F85EA81252940DEB00FC1FC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6DF020583EE6DD060F87A029</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>3FDB77D8C6B477F56F7331F9</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>18E7BE82797F36BC7315A524</string>
-				<string>FB8D122E5026B28059C55574</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>40C977BD65720FB89A08A869</key>
-		<dict>
-			<key>fileRef</key>
-			<string>307DC766F062DA6F22E0A8C2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>41A2D01B9AE6B55D4CB54B89</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9DB501DA0B2A3723253C024C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>420283FDC853B11367189E39</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>NYTPhotoViewerCloseButtonXLandscape.png</string>
-			<key>path</key>
-			<string>Pod/Assets/ios/NYTPhotoViewerCloseButtonXLandscape.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4233DAABFADA2023EB350D79</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMReturnValueProvider.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMReturnValueProvider.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>43399EC15351453AE666AECD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1A2EFE1FDE8C273E41FBFCF5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>4375A6EB96FD307D003D6671</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-environment.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>438A1D6371FE2E2DFF76093A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>85B981625089E45E1C42CDE4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>43C3CE9C3E3BC3BE4E3A1E16</key>
-		<dict>
-			<key>fileRef</key>
-			<string>87264381DE7CA6CDF3B56575</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>44800019A7D1F62A409C02AB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMockObject.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMockObject.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>44CEC4D954815E90731BFC57</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-Tests-OCMock</string>
-			<key>target</key>
-			<string>FB47254A4055AE3C774C5CF8</string>
-			<key>targetProxy</key>
-			<string>456ADE491FA4A185969E5BDD</string>
-		</dict>
-		<key>454140A94EADE7E64927003D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>7565230DB6A9620A1B094C7A</string>
-				<string>BC5143A55B56BDE2D80E6A12</string>
-				<string>6739E028DAF5E977D978AB7A</string>
-				<string>9D9A5BBD65D25652683834AC</string>
-				<string>3F85EA81252940DEB00FC1FC</string>
-				<string>FAD8B38EA65866441107E950</string>
-				<string>59C9858A15A458265D64BEEF</string>
-				<string>55D054D2215886D0B1033FED</string>
-				<string>A1988ACB88F28CCC5823DFBE</string>
-				<string>B03A7AADC52213AF71F0EDC6</string>
-				<string>AEE254640D562C309A321B2E</string>
-				<string>681441754AB5D7DF127B43C4</string>
-				<string>916E3295F81C6B45837EC1F2</string>
-				<string>9A3F5151AC6022733CA55E91</string>
-				<string>DF9044770C313D9F1904ACD9</string>
-				<string>808E08A0BA8F7D4F170C35FE</string>
-				<string>B5C4557DF08FC40123B38F31</string>
-				<string>7968FC48DFDA1B3785F73F4B</string>
-				<string>7830C2949BA1CB606CEF70CE</string>
-				<string>E830C9BDACBD1C723C425830</string>
-				<string>3A344E6D9333FED65A6300C8</string>
-				<string>0F7D347C6001BA07836F5F26</string>
-				<string>DB4D965D38C629A155F92D11</string>
-				<string>A260D88C2C987B8BD4191BA5</string>
-				<string>0E763D8CB6064F5D1EFF7599</string>
-				<string>36B833681C4F076BF56FCEBB</string>
-				<string>F19C5AD4A4FA60B998AE3EDE</string>
-				<string>C0549C6ED28303D10857AE69</string>
-				<string>A0BE4398BA32F3162D9D6562</string>
-				<string>05066F08A4081B2ADC64BFD6</string>
-				<string>FE1595AC8EBB317AA93524E4</string>
-				<string>21A88F51F216B0659EB3B76A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>456ADE491FA4A185969E5BDD</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>DB3F5DC7DE66FB7274E6FB52</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>FB47254A4055AE3C774C5CF8</string>
-			<key>remoteInfo</key>
-			<string>Pods-Tests-OCMock</string>
-		</dict>
-		<key>4570C9B61E0DA14C7E9C319B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9DD26D85E326E913CEE025D8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>45FB9190CA97B941207A4630</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NYTPhotosOverlayView.m</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotosOverlayView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>46A58C3669B50A2A63A8C185</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMPassByRefSetter.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMPassByRefSetter.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>46E6EFF02357FC93AF696272</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0AAA1B247A4A215F7A5907E3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>47299642D8B9EE530BB811E3</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EB760647CD2C6D6AF095ECD2</string>
-				<string>9F58613E0A68B64D461E3280</string>
-				<string>1629E9E9F8042A2096E475B3</string>
-				<string>BEF933B04E5D228A7A18ADDA</string>
-				<string>33DC27FA73F298AF8E69D7AB</string>
-				<string>EFA58414A5B2F1CBFC1BECAC</string>
-				<string>9B2915B5408DB212F1A872B0</string>
-				<string>E0A98A7C6AB18D4103E0D87A</string>
-				<string>AC9878B540D77AA436459189</string>
-				<string>903209471199CAEE3B42CA19</string>
-				<string>B9D0611732608546131C68AB</string>
-				<string>E2D401B06064CBCBE38FFEF4</string>
-				<string>9075BF902932F4D3B5717B4E</string>
-				<string>8C98F7877C29008627A2D842</string>
-				<string>FE7D9F49EDE8F22171327D20</string>
-				<string>D714BC42AFE98071E83FB55A</string>
-				<string>DCE4C4A3CC66AFA2646C365C</string>
-				<string>45FB9190CA97B941207A4630</string>
-				<string>62158E9CABF1BA176E6D4C59</string>
-				<string>87EB1BF6CEA3F1873E4FFA50</string>
-				<string>A2AA39193DA6E68F7B97B3A0</string>
-				<string>9DD26D85E326E913CEE025D8</string>
-				<string>B9164895990534371A09C187</string>
-				<string>1E38B48D281A26A00772C5A7</string>
-				<string>D5E7591FF624CA6AB3C1952D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>NYTPhotoViewer</string>
-			<key>path</key>
-			<string>../..</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4807A4121C26FE5BBFB5BBDB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E9ACDC7D73AD65931322460C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>49A80A0AD117B07B14D521F5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMNotificationPoster.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMNotificationPoster.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>49DE14448904B4D3FBDE54A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2569F5D65FEFD9942A27325B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>49E0C917D1519C6A9446AD9E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMockObject.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMockObject.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4AA001EFA3696F3A3ECC1C5A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMArg.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMArg.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4D59AED6FC23CA17EA99640F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>87EB1BF6CEA3F1873E4FFA50</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4D5AFE219FE801BFEBAD7183</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMObserverRecorder.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMObserverRecorder.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4D84B0B1828FF9F17EAE72CF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>34B5CAE55D0AED1F4718B537</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>4D9C87316D51A3019812E812</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EB760647CD2C6D6AF095ECD2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4E428710ECC26D09F7A781A1</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>F6E67ADB8E8582FDA08A8CBC</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>4F27CB1D26F356F78CFD3D06</key>
-		<dict>
-			<key>fileRef</key>
-			<string>22048393DB660082285AF393</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4F62A02EEC12B031041E9587</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4F69D2808E42983BA8814A4B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>62158E9CABF1BA176E6D4C59</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4F7F25301AED7A40B5D2CF06</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCObserverMockObject.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCObserverMockObject.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4F8314F6055C7954A72B9B51</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>9A1BC8AF7009E227336CD76E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>51091C5B419F91900ED19FB5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9B2915B5408DB212F1A872B0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5236B10EF0CBE94BF253E91A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DCE4C4A3CC66AFA2646C365C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>52C049C4964CFC4996FCDFD9</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>54E7CC5695D31BC468B4689E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9075BF902932F4D3B5717B4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>55D054D2215886D0B1033FED</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8647301F5C968345D6C65BB3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>56C60D5C34B45096E13A4ABE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EB760647CD2C6D6AF095ECD2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>574D9F0AFA4EF8C714F0444E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>ios</string>
-			<key>path</key>
-			<string>Pod/Assets/ios</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>58CC19214E17AD160D44D4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>903209471199CAEE3B42CA19</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>59865BA3CD478F735ABC11FC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6E60F98A792FD711A9EBB79B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>59C9858A15A458265D64BEEF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4AA001EFA3696F3A3ECC1C5A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>5A0B46673310BD28D06AE956</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-NYTPhotoViewer.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>5AF80A29F00DCD3525E738E7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>743F48CD04F7E076541BFC47</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5B02D56495BF8A566E8EA6AD</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NSNotificationCenter+OCMAdditions.h</string>
-			<key>path</key>
-			<string>Source/OCMock/NSNotificationCenter+OCMAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5D82D542EF99743A8B00FCE3</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>25009C60EF8844370FDAB21D</string>
-			<key>buildPhases</key>
-			<array>
-				<string>9D0B26B886340FEDD42C3E21</string>
-				<string>2666B9448C8F921C33BDE958</string>
-				<string>F3CDC348008DF5B1BB750686</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-NYTPhotoViewer</string>
-			<key>productName</key>
-			<string>Pods-NYTPhotoViewer-NYTPhotoViewer</string>
-			<key>productReference</key>
-			<string>9780D65FCFCBFB28EAB66199</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>5D8AC5A109BD394BDE891454</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMLocation.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMLocation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5E6E75B60A5A6C24DC969089</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3713D32BDA852095EA2A73DE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5F6CBF3D584CD42B55AEB1DF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMInvocationStub.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMInvocationStub.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5FF2A0F71C89297574749F2C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NSValue+OCMAdditions.h</string>
-			<key>path</key>
-			<string>Source/OCMock/NSValue+OCMAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>601C21199EE2C1DFA1BCB15C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>71BC5A9D64F89FE7331C73A3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>6079A0558D711495BE091573</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>607AF39C3A9F35E619C2C5C2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>33DC27FA73F298AF8E69D7AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>62158E9CABF1BA176E6D4C59</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTPhotosViewController.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotosViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>623099A9AF2218F7FF4A697D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EB760647CD2C6D6AF095ECD2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>62EEDDBF2AA6D86E983BF726</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5B02D56495BF8A566E8EA6AD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>636F3908B0DF40628CA7D3F8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FC05C962D1CFA81F0AD78A33</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6400B340CB182C73CFF3DF39</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>AB6C47E421D2D896FE250FF1</string>
-				<string>84E497D6958F5C7EA9AF407F</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>6478BC6DA1216C5C7E8AB64D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-Tests-OCMock.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-Tests-OCMock/Pods-Tests-OCMock.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>648B76D2318B3F724FE5AFAE</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>DB3F5DC7DE66FB7274E6FB52</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>85E8BD93A66999131D97D401</string>
-			<key>remoteInfo</key>
-			<string>Pods-NYTPhotoViewer-Swift-NYTPhotoViewer</string>
-		</dict>
-		<key>6492E956F099D5E6817648BA</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>85B981625089E45E1C42CDE4</string>
-				<string>EC61D2C6034C7A5815BE03F3</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>iOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>64F4BC5C2509CE1E037C55C2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>38E5FA1FF570E28DB4310AFF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>65CBB3F80E251AEA9104CB71</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMVerifier.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMVerifier.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>663FEDC2F9ED56FA60E637DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>49A80A0AD117B07B14D521F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>66D75152ED32E28D2FCE0ABE</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-Swift.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6739E028DAF5E977D978AB7A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>34B5CAE55D0AED1F4718B537</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>678241CA8DB67251FEDBBD97</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-Tests-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>681441754AB5D7DF127B43C4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F1BCFEA54E76501FBCB5E4C4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>68369090B42B85AEAB024660</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>874CCF36599385E29622AC1E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>684EFA81CC3B62CAF710A4D7</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMRecorder.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMRecorder.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>689FDA306464A152F43FD1F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F1BCFEA54E76501FBCB5E4C4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>68C7BA95CF440E9D0687A898</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMMacroState.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMMacroState.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>695CE4F613880545ADB04406</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>C9BB0C33DC6D2674A2650FDA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>69F0FC0376CE26BC3950F5B0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMRealObjectForwarder.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMRealObjectForwarder.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69FDB42127BB90AD54DC6372</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>37D61A65EE3B2675B96E4513</string>
-				<string>725008D6B50E0F9648C74393</string>
-				<string>11852500FC148A8C2C2CCBD8</string>
-				<string>AB7980B4555D832C08D56F85</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Targets Support Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6A31E6153B31E5AA4B08F6A1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-Tests.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6AAFD5D3F0224EFC6E97C5E8</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>6A31E6153B31E5AA4B08F6A1</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>6B058507325AC4344802BBCE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9B2915B5408DB212F1A872B0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6B1C3F40818CBFA16DF95C09</key>
-		<dict>
-			<key>fileRef</key>
-			<string>62158E9CABF1BA176E6D4C59</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6BC0C426D4F00674C04F48E0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A7885EBD8438F61F0BBF5DEE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6CCF7FB922A90B100BF3A650</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMIndirectReturnValueProvider.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMIndirectReturnValueProvider.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6D9AEF14DBBDA0549E60E96B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>85B981625089E45E1C42CDE4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6DBD7A586D69AB4384FC787E</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>D111BD4C163B390AEAF136CB</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-Tests-OCMock/Pods-Tests-OCMock-prefix.pch</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>6DF020583EE6DD060F87A029</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NSValue+OCMAdditions.m</string>
-			<key>path</key>
-			<string>Source/OCMock/NSValue+OCMAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6E60F98A792FD711A9EBB79B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NSInvocation+OCMAdditions.h</string>
-			<key>path</key>
-			<string>Source/OCMock/NSInvocation+OCMAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6ED37D4D6BF570E74AFE83F7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C381950D67F1AE46264A6AF8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6EEBAFE78B2CF2AF801D6733</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E0A98A7C6AB18D4103E0D87A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6F8A19FB9F12A9464B8E14ED</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMFunctions.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMFunctions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6FF81625A83435CF70264B05</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>NYTPhotoViewerCloseButtonX@2x.png</string>
-			<key>path</key>
-			<string>Pod/Assets/ios/NYTPhotoViewerCloseButtonX@2x.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>70548ECADB5332269E65AF4C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9B2915B5408DB212F1A872B0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>707AB77C486BF42D6CB5EEB4</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>RELEASE=1</string>
-				</array>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>70AA19CBF91B6EC6A634A222</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6E60F98A792FD711A9EBB79B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>70B6FBBC064CC361AB24C0DA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EFA58414A5B2F1CBFC1BECAC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>71BC5A9D64F89FE7331C73A3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMStubRecorder.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMStubRecorder.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>725008D6B50E0F9648C74393</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>C28EC605D89C35382082A6E2</string>
-				<string>9F3A7D773EBE5202342C4AA7</string>
-				<string>F4E78FC4A2B44F075EAE31FA</string>
-				<string>E6DAE5C9B678B75FB1C80454</string>
-				<string>CD9947A04D9C9E1BE5FF0B1D</string>
-				<string>AF43AB7738928F01FCFDF183</string>
-				<string>66D75152ED32E28D2FCE0ABE</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-Swift</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-NYTPhotoViewer-Swift</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7378F61C8B0BBFBE180039FB</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>47299642D8B9EE530BB811E3</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Development Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>738FD3CA96D7B232D196DF3D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>65CBB3F80E251AEA9104CB71</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>743F48CD04F7E076541BFC47</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCProtocolMockObject.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCProtocolMockObject.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>74FFAEFFFD2054400CC52B43</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-NYTPhotoViewer-Swift-NYTPhotoViewer.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>751F2F2940E6C6148A62FAC6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NSObject+OCMAdditions.m</string>
-			<key>path</key>
-			<string>Source/OCMock/NSObject+OCMAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7565230DB6A9620A1B094C7A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DE9BD92CACFDFD7DE3D8533B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>75E0863BEC7C298CA54E0C41</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-Tests-OCMock.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>760590D187902346DB2BCFC9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B9D0611732608546131C68AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>780B3D1D92E1C2E92E6C1B6B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>46A58C3669B50A2A63A8C185</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>781B44CA573D65EFEDB7ED86</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BEF933B04E5D228A7A18ADDA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7830C2949BA1CB606CEF70CE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68C7BA95CF440E9D0687A898</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>7968FC48DFDA1B3785F73F4B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5D8AC5A109BD394BDE891454</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>7B54D14A71AB5B0F16465842</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DCE4C4A3CC66AFA2646C365C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7C0F5C2FCCF6271836A3C232</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>5A0B46673310BD28D06AE956</string>
-				<string>9780D65FCFCBFB28EAB66199</string>
-				<string>D68D0582B96DB4EDB28B7091</string>
-				<string>74FFAEFFFD2054400CC52B43</string>
-				<string>806A3C92AC1C8976713B07B4</string>
-				<string>11D73809917EC52B050827A3</string>
-				<string>CF7C82773CF45E8ABC34D9BC</string>
-				<string>3B934FCE1F8716091A32FE81</string>
-				<string>8B0ACC9B5708AD621EE5F694</string>
-				<string>75E0863BEC7C298CA54E0C41</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7C54572B7B7AE9D54D75486F</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4F27CB1D26F356F78CFD3D06</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>7C79097821A783E5E40B9721</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>9073322179745DC90D4B1394</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>7DA238E069D679F3A7D49F19</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>7DCF3F784593A0129B36C179</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EFA58414A5B2F1CBFC1BECAC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7E16BF7E80E66C9BAA600481</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69F0FC0376CE26BC3950F5B0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>7E67C1CC845E11FBFD6A0365</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>Pods-Tests-OCMock-prefix.pch</string>
-			<key>path</key>
-			<string>../Pods-Tests-OCMock/Pods-Tests-OCMock-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7EB9E346E3DA38232A849273</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8C98F7877C29008627A2D842</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7EC47F014DF1D58DA8A1DE1E</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>7F1B41130A03CDC9789CDEDE</string>
-				<string>E3FF72A44A06BE2DE21C2270</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>7ED9B5A247E60C8B705F6C7D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-prefix.pch</string>
-			<key>path</key>
-			<string>../Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7F1B41130A03CDC9789CDEDE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>85B981625089E45E1C42CDE4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7F67EE3634297DF862DA26A1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>806A3C92AC1C8976713B07B4</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-NYTPhotoViewer-SwiftTests.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>808E08A0BA8F7D4F170C35FE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0AAA1B247A4A215F7A5907E3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>8229F2538A10468699323314</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2CAB01BCB2E5807A82F681E7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>842A2075DABDAF0691AA7D0E</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>7DA238E069D679F3A7D49F19</string>
-				<string>707AB77C486BF42D6CB5EEB4</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>84E497D6958F5C7EA9AF407F</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>33DB338CD9DE1D0398777F16</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-Tests-NYTPhotoViewer/Pods-Tests-NYTPhotoViewer-prefix.pch</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>856456FA1A25692FEFC3FE28</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMExceptionReturnValueProvider.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMExceptionReturnValueProvider.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>85B981625089E45E1C42CDE4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>85E8BD93A66999131D97D401</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>A8C18131BB772509B70A9B7D</string>
-			<key>buildPhases</key>
-			<array>
-				<string>3EA0E04E44A11259FD882560</string>
-				<string>95E635757BB30FAC83F6C156</string>
-				<string>9080749D52787FEA52932EC3</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-Swift-NYTPhotoViewer</string>
-			<key>productName</key>
-			<string>Pods-NYTPhotoViewer-Swift-NYTPhotoViewer</string>
-			<key>productReference</key>
-			<string>74FFAEFFFD2054400CC52B43</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>8647301F5C968345D6C65BB3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMBlockCaller.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMBlockCaller.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>86B43563820BACECDECDBA14</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-NYTPhotoViewer-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>86E991077FF6A2C02EA1D0D1</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>16FAD106A2022C3575D8A3AB</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>871DA85373568ABBE7D03370</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>D111BD4C163B390AEAF136CB</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-Tests-OCMock/Pods-Tests-OCMock-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>87264381DE7CA6CDF3B56575</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCClassMockObject.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCClassMockObject.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>874CCF36599385E29622AC1E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>85B981625089E45E1C42CDE4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>878568BFE16D81A4A00DD87A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC61D2C6034C7A5815BE03F3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>87D7512B79AA4C9ECA874EB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>44800019A7D1F62A409C02AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>87EB1BF6CEA3F1873E4FFA50</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NYTPhotosViewController.m</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotosViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>88FFB8E8CE680E58AE696CD7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DCE4C4A3CC66AFA2646C365C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>89FB1B1782E6BFD561C3CD14</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5FF2A0F71C89297574749F2C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8A71387381A723E740927E59</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NSObject+OCMAdditions.h</string>
-			<key>path</key>
-			<string>Source/OCMock/NSObject+OCMAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8B0ACC9B5708AD621EE5F694</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-Tests-NYTPhotoViewer.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>8B8D98DF6B861C3866837A92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B0222A66BB9F7F439575B8F0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8C98F7877C29008627A2D842</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NYTPhotoViewController.m</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotoViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8EDBA5F0FCBCCED6E39BEEA1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5FF2A0F71C89297574749F2C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8F204A9D76A8F45D856BE530</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4233DAABFADA2023EB350D79</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>903209471199CAEE3B42CA19</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NYTPhotoTransitionAnimator.m</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotoTransitionAnimator.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9066D53EDD0479E5742F0631</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9DD26D85E326E913CEE025D8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9073322179745DC90D4B1394</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F4E78FC4A2B44F075EAE31FA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9075BF902932F4D3B5717B4E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTPhotoViewController.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotoViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9080749D52787FEA52932EC3</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>56C60D5C34B45096E13A4ABE</string>
-				<string>AA8E4B00B7D93C4345BDBC03</string>
-				<string>99EDE1F605E9270D670B70C1</string>
-				<string>7DCF3F784593A0129B36C179</string>
-				<string>51091C5B419F91900ED19FB5</string>
-				<string>AB2D2BDDCB26DB31EADE1EA4</string>
-				<string>760590D187902346DB2BCFC9</string>
-				<string>976E372E2004153FD3F85890</string>
-				<string>D89EBF50F6B5D580566FEAC5</string>
-				<string>5236B10EF0CBE94BF253E91A</string>
-				<string>4F69D2808E42983BA8814A4B</string>
-				<string>39870B1D6DB0C778CBF6D749</string>
-				<string>4570C9B61E0DA14C7E9C319B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>909C6DB1829CB8D53D6B5BE9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B9164895990534371A09C187</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>909E4A4842ED3B4B3B96CB32</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>NYTPhotoViewerCloseButtonX.png</string>
-			<key>path</key>
-			<string>Pod/Assets/ios/NYTPhotoViewerCloseButtonX.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>916E3295F81C6B45837EC1F2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9846BBCE91D248C6CBDC83C1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>91824627BDD99B2A2A6C3C99</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B0222A66BB9F7F439575B8F0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>918AC8496C7782C8A3A27FD8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMArg.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMArg.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>918FD1D39CB234CB639D33EC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FE7D9F49EDE8F22171327D20</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9231A601A6094B3BBBB3C1B1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D7B9932B3747FDA8D1A6FF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>93188388DFD83F2E61EC26E8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9F58613E0A68B64D461E3280</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>94076555791A8A5E89ACC230</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2569F5D65FEFD9942A27325B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>948C084D5D6EF42AF89FB510</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6F8A19FB9F12A9464B8E14ED</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>959C8D3D088313E20DA6AB65</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-dummy.m</string>
-			<key>path</key>
-			<string>../Pods-NYTPhotoViewer-Swift-NYTPhotoViewer/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>95E635757BB30FAC83F6C156</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>E734218E81D4249D07D22ADC</string>
-				<string>878568BFE16D81A4A00DD87A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>976E372E2004153FD3F85890</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9075BF902932F4D3B5717B4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9780D65FCFCBFB28EAB66199</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-NYTPhotoViewer-NYTPhotoViewer.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>9846BBCE91D248C6CBDC83C1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMFunctions.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMFunctions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>99C41C502164EF6C5DDCB7AE</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-Tests-NYTPhotoViewer</string>
-			<key>target</key>
-			<string>0447139662D4FCA4E4612E05</string>
-			<key>targetProxy</key>
-			<string>2D126C1BB9864B0106EE5884</string>
-		</dict>
-		<key>99EDE1F605E9270D670B70C1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BEF933B04E5D228A7A18ADDA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9A1BC8AF7009E227336CD76E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>85B981625089E45E1C42CDE4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9A1D8FF3FECAE266DF1919F9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8A71387381A723E740927E59</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9A3F5151AC6022733CA55E91</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6CCF7FB922A90B100BF3A650</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>9A6B20E0E7794E652E5306DA</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>59865BA3CD478F735ABC11FC</string>
-				<string>D8EC2EE0938292DEF26EA394</string>
-				<string>62EEDDBF2AA6D86E983BF726</string>
-				<string>9A1D8FF3FECAE266DF1919F9</string>
-				<string>89FB1B1782E6BFD561C3CD14</string>
-				<string>1B53F2FDEF2057318516A931</string>
-				<string>FBA5E233A118EFFE1233BD71</string>
-				<string>C4C1D864972C9E7744269700</string>
-				<string>0164B49DEBF3FD09112BAF54</string>
-				<string>E71C3BB6E5CB1528E12A96A3</string>
-				<string>2AB8C29105D31E289D65839B</string>
-				<string>2FCC37CD4A39646933819732</string>
-				<string>ACEE50D48728EEB5F8354922</string>
-				<string>BAC56D667FF286D6330E4FE0</string>
-				<string>49DE14448904B4D3FBDE54A6</string>
-				<string>41A2D01B9AE6B55D4CB54B89</string>
-				<string>F2D49A50BCDAB974F67D4CF2</string>
-				<string>1B588B1D79BF7E420074A990</string>
-				<string>91824627BDD99B2A2A6C3C99</string>
-				<string>C16378DE0EAF98AB527A74BE</string>
-				<string>F8D52EC26C2F32AAA5DFA3B2</string>
-				<string>CD9741B7AE164912BECE1F01</string>
-				<string>C0D0820115B685438F44A32B</string>
-				<string>F7E5179949F07ED158C3C824</string>
-				<string>22A1B39DABC21B6183F22CCB</string>
-				<string>5E6E75B60A5A6C24DC969089</string>
-				<string>ED57D537BB3EB8AD68D997C0</string>
-				<string>64F4BC5C2509CE1E037C55C2</string>
-				<string>37F8EDFD997F8B953C6B679A</string>
-				<string>4807A4121C26FE5BBFB5BBDB</string>
-				<string>6BC0C426D4F00674C04F48E0</string>
-				<string>DDB89B3EFA729D467B4CEC86</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>9B040E70EDBEAEADF8496E0E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-Tests-environment.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9B2915B5408DB212F1A872B0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTPhotoDismissalInteractionController.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotoDismissalInteractionController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9B9C54F6E71DF765B769FF6A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DE9BD92CACFDFD7DE3D8533B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>9C786A328D2718F86DBDCFEB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>Pods-Tests-NYTPhotoViewer-prefix.pch</string>
-			<key>path</key>
-			<string>../Pods-Tests-NYTPhotoViewer/Pods-Tests-NYTPhotoViewer-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9D0B26B886340FEDD42C3E21</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>FD81BE22F42799FEA42A0ADD</string>
-				<string>C182E01E0A7EC5A4484C4B41</string>
-				<string>B7FC7819993344BCA62B186E</string>
-				<string>EB03C6769464BB66A4DC65C3</string>
-				<string>9F2E72395D58FAE18BA21DA7</string>
-				<string>7EB9E346E3DA38232A849273</string>
-				<string>CBA53F104597B700D89B97CE</string>
-				<string>A308017BF4CCA6DC097E201A</string>
-				<string>E7BF65213D7FBC77F8FF1363</string>
-				<string>DE0AC62E6C5E4576E1752919</string>
-				<string>2CC43C113F8A24E48629AC04</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>9D87D675530D9E1778566F6E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9D9A5BBD65D25652683834AC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>751F2F2940E6C6148A62FAC6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>9DB501DA0B2A3723253C024C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMInvocationMatcher.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMInvocationMatcher.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9DD26D85E326E913CEE025D8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTScalingImageView.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTScalingImageView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9E635BC1289151E5254E4293</key>
-		<dict>
-			<key>fileRef</key>
-			<string>87EB1BF6CEA3F1873E4FFA50</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9F2E72395D58FAE18BA21DA7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E2D401B06064CBCBE38FFEF4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9F3A7D773EBE5202342C4AA7</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-Swift-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9F58613E0A68B64D461E3280</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NYTOperatingSystemCompatibilityUtility.m</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTOperatingSystemCompatibilityUtility.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9FB3EC2C4D5F6F924DF2EBBA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMPassByRefSetter.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMPassByRefSetter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A0BE4398BA32F3162D9D6562</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4F7F25301AED7A40B5D2CF06</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>A15831F42ECC7BF14C293DE2</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>3FDB77D8C6B477F56F7331F9</string>
-			<key>buildPhases</key>
-			<array>
-				<string>7C54572B7B7AE9D54D75486F</string>
-				<string>68369090B42B85AEAB024660</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>23EB7844D274BDFC2579DE6D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer</string>
-			<key>productName</key>
-			<string>Pods-NYTPhotoViewer</string>
-			<key>productReference</key>
-			<string>5A0B46673310BD28D06AE956</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>A1988ACB88F28CCC5823DFBE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2DDA1EE2FA4741E1C1A57FAB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>A260D88C2C987B8BD4191BA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>684EFA81CC3B62CAF710A4D7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>A2AA39193DA6E68F7B97B3A0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTPhotosViewControllerDataSource.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/Protocols/NYTPhotosViewControllerDataSource.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A308017BF4CCA6DC097E201A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>45FB9190CA97B941207A4630</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A3C38321E78A8DD16837EC35</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>BF8080268106641E4FF15D47</string>
-				<string>6AAFD5D3F0224EFC6E97C5E8</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>A4CFAA11A09B96994A21D71B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>130B84B5FC7EDFBA3CF03BD8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>A6576F5C17D55F184B65EB3A</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>AF43AB7738928F01FCFDF183</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>A7885EBD8438F61F0BBF5DEE</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCPartialMockObject.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCPartialMockObject.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A8C18131BB772509B70A9B7D</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>695CE4F613880545ADB04406</string>
-				<string>36D74CC47D031BBCFE491FE9</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>A8C1DC03AB82353078AB0FB1</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6E60F98A792FD711A9EBB79B</string>
-				<string>DE9BD92CACFDFD7DE3D8533B</string>
-				<string>C34EE63F2441725BAE7C1B69</string>
-				<string>E26846BA9A7F6C234C6AFD85</string>
-				<string>5B02D56495BF8A566E8EA6AD</string>
-				<string>34B5CAE55D0AED1F4718B537</string>
-				<string>8A71387381A723E740927E59</string>
-				<string>751F2F2940E6C6148A62FAC6</string>
-				<string>5FF2A0F71C89297574749F2C</string>
-				<string>6DF020583EE6DD060F87A029</string>
-				<string>87264381DE7CA6CDF3B56575</string>
-				<string>E031EE8F4B8D8A72CCBB2B85</string>
-				<string>918AC8496C7782C8A3A27FD8</string>
-				<string>4AA001EFA3696F3A3ECC1C5A</string>
-				<string>307DC766F062DA6F22E0A8C2</string>
-				<string>8647301F5C968345D6C65BB3</string>
-				<string>F262EA2711B86BFF08D5DA96</string>
-				<string>2DDA1EE2FA4741E1C1A57FAB</string>
-				<string>2739CDA5AB001D7AEFEF9734</string>
-				<string>ACE8A9A636D7CE6B4411216A</string>
-				<string>856456FA1A25692FEFC3FE28</string>
-				<string>1A2EFE1FDE8C273E41FBFCF5</string>
-				<string>1C15D35E2817745B63904821</string>
-				<string>F1BCFEA54E76501FBCB5E4C4</string>
-				<string>6F8A19FB9F12A9464B8E14ED</string>
-				<string>9846BBCE91D248C6CBDC83C1</string>
-				<string>07BAB14A5F32DDF1574F2E99</string>
-				<string>6CCF7FB922A90B100BF3A650</string>
-				<string>2569F5D65FEFD9942A27325B</string>
-				<string>0173576ECF18C2B5B84DA883</string>
-				<string>9DB501DA0B2A3723253C024C</string>
-				<string>0AAA1B247A4A215F7A5907E3</string>
-				<string>5F6CBF3D584CD42B55AEB1DF</string>
-				<string>B9259EA232551DA556BEF6BC</string>
-				<string>1944CBEDD7EB3F42ABB7035D</string>
-				<string>5D8AC5A109BD394BDE891454</string>
-				<string>B0222A66BB9F7F439575B8F0</string>
-				<string>68C7BA95CF440E9D0687A898</string>
-				<string>49A80A0AD117B07B14D521F5</string>
-				<string>B8D7B9932B3747FDA8D1A6FF</string>
-				<string>4D5AFE219FE801BFEBAD7183</string>
-				<string>CABBA1BAA3054F876B0C8F01</string>
-				<string>9FB3EC2C4D5F6F924DF2EBBA</string>
-				<string>46A58C3669B50A2A63A8C185</string>
-				<string>FC05C962D1CFA81F0AD78A33</string>
-				<string>69F0FC0376CE26BC3950F5B0</string>
-				<string>C3238309106D63A91FE528C9</string>
-				<string>684EFA81CC3B62CAF710A4D7</string>
-				<string>FA3488EC2BDD028C8EB901C0</string>
-				<string>4233DAABFADA2023EB350D79</string>
-				<string>3713D32BDA852095EA2A73DE</string>
-				<string>71BC5A9D64F89FE7331C73A3</string>
-				<string>CA18D29B4A53538648260D21</string>
-				<string>65CBB3F80E251AEA9104CB71</string>
-				<string>38E5FA1FF570E28DB4310AFF</string>
-				<string>44800019A7D1F62A409C02AB</string>
-				<string>49E0C917D1519C6A9446AD9E</string>
-				<string>E9ACDC7D73AD65931322460C</string>
-				<string>4F7F25301AED7A40B5D2CF06</string>
-				<string>A7885EBD8438F61F0BBF5DEE</string>
-				<string>B2926136463FFA4168502AA1</string>
-				<string>743F48CD04F7E076541BFC47</string>
-				<string>130B84B5FC7EDFBA3CF03BD8</string>
-				<string>2DE06652D777E39D9A720FDD</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>OCMock</string>
-			<key>path</key>
-			<string>OCMock</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AA8E4B00B7D93C4345BDBC03</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1629E9E9F8042A2096E475B3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AAA8E9CA90F9F4E53479B764</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-Tests-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AB2D2BDDCB26DB31EADE1EA4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC9878B540D77AA436459189</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AB6C47E421D2D896FE250FF1</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>33DB338CD9DE1D0398777F16</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-Tests-NYTPhotoViewer/Pods-Tests-NYTPhotoViewer-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>AB7980B4555D832C08D56F85</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>AAA8E9CA90F9F4E53479B764</string>
-				<string>F8846770DB6FA58A8155EE1B</string>
-				<string>C381950D67F1AE46264A6AF8</string>
-				<string>9B040E70EDBEAEADF8496E0E</string>
-				<string>678241CA8DB67251FEDBBD97</string>
-				<string>E10ACCFC67198E49FA479F63</string>
-				<string>6A31E6153B31E5AA4B08F6A1</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-Tests</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-Tests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC9878B540D77AA436459189</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTPhotoTransitionAnimator.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotoTransitionAnimator.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACD68F5FDE643665CB9CBD6A</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>86B43563820BACECDECDBA14</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-NYTPhotoViewer-NYTPhotoViewer/Pods-NYTPhotoViewer-NYTPhotoViewer-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>ACE8A9A636D7CE6B4411216A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMConstraint.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMConstraint.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACEE50D48728EEB5F8354922</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6F8A19FB9F12A9464B8E14ED</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AE3D542786E8E1FF3ADACDE1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC9878B540D77AA436459189</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AEE254640D562C309A321B2E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1A2EFE1FDE8C273E41FBFCF5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>AF43AB7738928F01FCFDF183</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-Swift.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B0144A696A1552A965AE5DA3</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-OCMock-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B0222A66BB9F7F439575B8F0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMMacroState.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMMacroState.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B03A7AADC52213AF71F0EDC6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACE8A9A636D7CE6B4411216A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>B12F9AC1F97C4FE18FA0DD03</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-NYTPhotoViewer-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B1BE80CC0876C7C8D948CC30</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3713D32BDA852095EA2A73DE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B22382FAC747585AFC66A1A0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9075BF902932F4D3B5717B4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B25294FB0CF98C5B8D595A88</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-OCMock.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B2926136463FFA4168502AA1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCPartialMockObject.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCPartialMockObject.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B337DC4CDE59F58D6651F43D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4F7F25301AED7A40B5D2CF06</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>B3B96ABE1A56CDFBB87DED83</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>name</key>
-			<string>NYTPhotoViewerCloseButtonXLandscape@2x.png</string>
-			<key>path</key>
-			<string>Pod/Assets/ios/NYTPhotoViewerCloseButtonXLandscape@2x.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B44CD330DF715C17F797AA32</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E031EE8F4B8D8A72CCBB2B85</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>B55134BD22538F5C7D0AACBD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DCE4C4A3CC66AFA2646C365C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B5C4557DF08FC40123B38F31</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B9259EA232551DA556BEF6BC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>B720DA40341976378A8B14AE</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-Tests-NYTPhotoViewer.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-Tests-NYTPhotoViewer/Pods-Tests-NYTPhotoViewer.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B7FC7819993344BCA62B186E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E0A98A7C6AB18D4103E0D87A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B8D7B9932B3747FDA8D1A6FF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMNotificationPoster.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMNotificationPoster.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B8ECEB7C3984D842060812B7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>45FB9190CA97B941207A4630</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B9164895990534371A09C187</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NYTScalingImageView.m</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTScalingImageView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B9259EA232551DA556BEF6BC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMInvocationStub.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMInvocationStub.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B9D0611732608546131C68AB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTPhotoTransitionController.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotoTransitionController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BABDAC7DF5EC609B14B5E411</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B9164895990534371A09C187</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BAC56D667FF286D6330E4FE0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>07BAB14A5F32DDF1574F2E99</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BACF355C620F956C3380C7D6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9B2915B5408DB212F1A872B0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BC5143A55B56BDE2D80E6A12</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E26846BA9A7F6C234C6AFD85</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>BC70C00E99E3001779951F4F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>024111B35564B48AE0023AA9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BCA6F469A10130F901ECA84D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>93188388DFD83F2E61EC26E8</string>
-				<string>607AF39C3A9F35E619C2C5C2</string>
-				<string>6EEBAFE78B2CF2AF801D6733</string>
-				<string>58CC19214E17AD160D44D4DD</string>
-				<string>E2140C737209892D3F8C460F</string>
-				<string>C3DD6609296FBEB3E529A01B</string>
-				<string>EB3F8ABB51CBE9292B3A8E08</string>
-				<string>B8ECEB7C3984D842060812B7</string>
-				<string>2B251A189EC557DDDDDA469E</string>
-				<string>2C05312A1C90F8175B932164</string>
-				<string>DFF2FC54C20ADD0E8CF29271</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>BCF5CF2871A2C6A8BE39E35E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>684EFA81CC3B62CAF710A4D7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>BD575CDF7A4663127252C464</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D714BC42AFE98071E83FB55A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BDB99FA97F7D612B728DBA1B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9DD26D85E326E913CEE025D8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BED3EC187AD227769E074EF8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6CCF7FB922A90B100BF3A650</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>BEEB5CDD41FFE788B7B0ADBB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EFA58414A5B2F1CBFC1BECAC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BEF933B04E5D228A7A18ADDA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTPhotoCaptionView.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotoCaptionView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BF0D05246C62850F5776E5C1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-NYTPhotoViewer-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BF8080268106641E4FF15D47</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>E10ACCFC67198E49FA479F63</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>C0433EC9D69288656B8A48D0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6DF020583EE6DD060F87A029</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>C0549C6ED28303D10857AE69</key>
-		<dict>
-			<key>fileRef</key>
-			<string>49E0C917D1519C6A9446AD9E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>C0D0820115B685438F44A32B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FC05C962D1CFA81F0AD78A33</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C11D170EA81F64A153CC4248</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5B02D56495BF8A566E8EA6AD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C16378DE0EAF98AB527A74BE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>49A80A0AD117B07B14D521F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C182E01E0A7EC5A4484C4B41</key>
-		<dict>
-			<key>fileRef</key>
-			<string>33DC27FA73F298AF8E69D7AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C28EC605D89C35382082A6E2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-Swift-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C32125E4A6AF66AA52B71B95</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1629E9E9F8042A2096E475B3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C3238309106D63A91FE528C9</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMRecorder.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMRecorder.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C34EE63F2441725BAE7C1B69</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NSMethodSignature+OCMAdditions.h</string>
-			<key>path</key>
-			<string>Source/OCMock/NSMethodSignature+OCMAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C381950D67F1AE46264A6AF8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-Tests-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C3DD6609296FBEB3E529A01B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8C98F7877C29008627A2D842</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C4C1D864972C9E7744269700</key>
-		<dict>
-			<key>fileRef</key>
-			<string>307DC766F062DA6F22E0A8C2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C4DD9FFBE917BC0D311424FB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC61D2C6034C7A5815BE03F3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C52ABCCFDD6F6C846C66BC06</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC9878B540D77AA436459189</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C8418D3444A8D2C48151B255</key>
-		<dict>
-			<key>fileRef</key>
-			<string>918AC8496C7782C8A3A27FD8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C921BC00C737DACBEE8A1920</key>
-		<dict>
-			<key>fileRef</key>
-			<string>85B981625089E45E1C42CDE4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C9600506CAF4F1B41F3C8435</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1629E9E9F8042A2096E475B3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C9BB0C33DC6D2674A2650FDA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-Private.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-NYTPhotoViewer-Swift-NYTPhotoViewer/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CA18D29B4A53538648260D21</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMVerifier.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMVerifier.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CABBA1BAA3054F876B0C8F01</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMObserverRecorder.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMObserverRecorder.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CB6E4EEDCB390C75488510AF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B9D0611732608546131C68AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CB9CD201886329065C717498</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CBA53F104597B700D89B97CE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D714BC42AFE98071E83FB55A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC241B9D4900E0BAC7643572</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>86E991077FF6A2C02EA1D0D1</string>
-				<string>CE87D0F538BC5DA79FC0BB66</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>CCE66B93D04970FE98EA21DC</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-OCMock</string>
-			<key>target</key>
-			<string>2104855B84EF13FE632EC212</string>
-			<key>targetProxy</key>
-			<string>EEEA7EBB25EF27D55ABA4FD6</string>
-		</dict>
-		<key>CD9741B7AE164912BECE1F01</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9FB3EC2C4D5F6F924DF2EBBA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CD9947A04D9C9E1BE5FF0B1D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-Swift-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CE87D0F538BC5DA79FC0BB66</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>16FAD106A2022C3575D8A3AB</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-prefix.pch</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>CEBDB13E5A86E6C704C84944</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>0CBCEC4163FB3ADE88A24B80</string>
-				<string>C9600506CAF4F1B41F3C8435</string>
-				<string>32CD52FD28A787B9FE09E9F4</string>
-				<string>BEEB5CDD41FFE788B7B0ADBB</string>
-				<string>BACF355C620F956C3380C7D6</string>
-				<string>F6AF54630700F5E9C5C2CC7D</string>
-				<string>06DA2E7E2D69F82C0A3DA20C</string>
-				<string>B22382FAC747585AFC66A1A0</string>
-				<string>D9820C3FB72CA3E883C794B6</string>
-				<string>7B54D14A71AB5B0F16465842</string>
-				<string>ECFD0B9B4877B1B42B71F472</string>
-				<string>183BB060A9ADD0F503B6B2DA</string>
-				<string>9066D53EDD0479E5742F0631</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>CF7C82773CF45E8ABC34D9BC</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-NYTPhotoViewer-SwiftTests-OCMock.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>D111BD4C163B390AEAF136CB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-Tests-OCMock-Private.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-Tests-OCMock/Pods-Tests-OCMock-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D28B95ECC09DA0CE5B579F77</key>
-		<dict>
-			<key>fileRef</key>
-			<string>903209471199CAEE3B42CA19</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D2C3D477134FE14E09FC534B</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>A8C1DC03AB82353078AB0FB1</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D3585DE44F744998B63E2F8E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-OCMock-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D3E3AEE239D58900B1A098AB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B9D0611732608546131C68AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D53D752AF09654956A95CB44</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C34EE63F2441725BAE7C1B69</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D5CD36836C52834E1C11C329</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4D5AFE219FE801BFEBAD7183</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D5E7591FF624CA6AB3C1952D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E1FCC4F652AA3FDA50D64379</string>
-				<string>86B43563820BACECDECDBA14</string>
-				<string>B12F9AC1F97C4FE18FA0DD03</string>
-				<string>BF0D05246C62850F5776E5C1</string>
-				<string>F2BE408A7422AFE4DE7B67E2</string>
-				<string>C9BB0C33DC6D2674A2650FDA</string>
-				<string>959C8D3D088313E20DA6AB65</string>
-				<string>E096CC3BD1B1819E9AC7C755</string>
-				<string>6079A0558D711495BE091573</string>
-				<string>16FAD106A2022C3575D8A3AB</string>
-				<string>1FE1180B890870E37CBC1D98</string>
-				<string>7ED9B5A247E60C8B705F6C7D</string>
-				<string>B720DA40341976378A8B14AE</string>
-				<string>33DB338CD9DE1D0398777F16</string>
-				<string>F13CABD95AF1FEB2271C600E</string>
-				<string>9C786A328D2718F86DBDCFEB</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>Example/Pods/Target Support Files/Pods-NYTPhotoViewer-NYTPhotoViewer</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D68D0582B96DB4EDB28B7091</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-NYTPhotoViewer-Swift.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>D714BC42AFE98071E83FB55A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NYTPhotosDataSource.m</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotosDataSource.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D89EBF50F6B5D580566FEAC5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FE7D9F49EDE8F22171327D20</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D8CDD718588A07F65EFC97E3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B9259EA232551DA556BEF6BC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>D8EC2EE0938292DEF26EA394</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C34EE63F2441725BAE7C1B69</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D9820C3FB72CA3E883C794B6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FE7D9F49EDE8F22171327D20</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DACEF04843F4D3AAB41E45B9</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>CC241B9D4900E0BAC7643572</string>
-			<key>buildPhases</key>
-			<array>
-				<string>BCA6F469A10130F901ECA84D</string>
-				<string>1DA147F57555614CEA3BA0A2</string>
-				<string>CEBDB13E5A86E6C704C84944</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer</string>
-			<key>productName</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer</string>
-			<key>productReference</key>
-			<string>11D73809917EC52B050827A3</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>DB3F5DC7DE66FB7274E6FB52</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastUpgradeCheck</key>
-				<string>0510</string>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>842A2075DABDAF0691AA7D0E</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>300D825A591949CAB22D43DF</string>
-			<key>productRefGroup</key>
-			<string>7C0F5C2FCCF6271836A3C232</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>A15831F42ECC7BF14C293DE2</string>
-				<string>5D82D542EF99743A8B00FCE3</string>
-				<string>09DE7D921811F6AD29841E02</string>
-				<string>85E8BD93A66999131D97D401</string>
-				<string>F2877E4932031B6DB35FA0E3</string>
-				<string>DACEF04843F4D3AAB41E45B9</string>
-				<string>2104855B84EF13FE632EC212</string>
-				<string>E0ED2EDB9A6415A056DE5CFB</string>
-				<string>0447139662D4FCA4E4612E05</string>
-				<string>FB47254A4055AE3C774C5CF8</string>
-			</array>
-		</dict>
-		<key>DB4D965D38C629A155F92D11</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69F0FC0376CE26BC3950F5B0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>DBAF899A63B79796E5009645</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>871DA85373568ABBE7D03370</string>
-				<string>6DBD7A586D69AB4384FC787E</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>DC79D46F4D4D676614C38DAA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FA3488EC2BDD028C8EB901C0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DCE4C4A3CC66AFA2646C365C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTPhotosOverlayView.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotosOverlayView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DD68A2A3D11BE1C6A3C0B1C3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>903209471199CAEE3B42CA19</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DD996922D0E95E131F95FF1D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>70AA19CBF91B6EC6A634A222</string>
-				<string>D53D752AF09654956A95CB44</string>
-				<string>C11D170EA81F64A153CC4248</string>
-				<string>E20E6ECED2388FC746048E77</string>
-				<string>8EDBA5F0FCBCCED6E39BEEA1</string>
-				<string>43C3CE9C3E3BC3BE4E3A1E16</string>
-				<string>C8418D3444A8D2C48151B255</string>
-				<string>40C977BD65720FB89A08A869</string>
-				<string>152A783F03F3584D6CF20251</string>
-				<string>26DCE245D3925CEB3A8D0FDB</string>
-				<string>015E0414AD24281005E5750C</string>
-				<string>0B77D3608D09516179FFEDC8</string>
-				<string>948C084D5D6EF42AF89FB510</string>
-				<string>F0F1A28D19832F854C732D1E</string>
-				<string>94076555791A8A5E89ACC230</string>
-				<string>F2AB71D4DAF54BFD1B1FA44E</string>
-				<string>E063BC2BB5F0A56E31D6C061</string>
-				<string>1A5CE29D7708C2092B5F0082</string>
-				<string>8B8D98DF6B861C3866837A92</string>
-				<string>663FEDC2F9ED56FA60E637DD</string>
-				<string>D5CD36836C52834E1C11C329</string>
-				<string>EDE4D8460746F33533829640</string>
-				<string>636F3908B0DF40628CA7D3F8</string>
-				<string>2F8AA59CA858EB5DA740B810</string>
-				<string>DC79D46F4D4D676614C38DAA</string>
-				<string>B1BE80CC0876C7C8D948CC30</string>
-				<string>2F54BB8FA3B465875CA7D6F7</string>
-				<string>14C54B648E45B84FB7ADF9D4</string>
-				<string>87D7512B79AA4C9ECA874EB2</string>
-				<string>139760EB2F3134E3C8A0510C</string>
-				<string>3CC92C10E7DBA6CBF22A489F</string>
-				<string>5AF80A29F00DCD3525E738E7</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>DDB89B3EFA729D467B4CEC86</key>
-		<dict>
-			<key>fileRef</key>
-			<string>743F48CD04F7E076541BFC47</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DE0AC62E6C5E4576E1752919</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B9164895990534371A09C187</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DE9BD92CACFDFD7DE3D8533B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NSInvocation+OCMAdditions.m</string>
-			<key>path</key>
-			<string>Source/OCMock/NSInvocation+OCMAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DF8B2633864CE2EE3E36A1EA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DF9044770C313D9F1904ACD9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0173576ECF18C2B5B84DA883</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>DF9B79E0887A8BA249670C1B</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>3340CF0CEFCDE830FB2E1835</string>
-				<string>2A66465343511DE9BFA03B77</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>DFF18B0468F16A6093E25876</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>6ED37D4D6BF570E74AFE83F7</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>DFF2FC54C20ADD0E8CF29271</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1FE1180B890870E37CBC1D98</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E031EE8F4B8D8A72CCBB2B85</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCClassMockObject.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCClassMockObject.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E063BC2BB5F0A56E31D6C061</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5F6CBF3D584CD42B55AEB1DF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E096CC3BD1B1819E9AC7C755</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-prefix.pch</string>
-			<key>path</key>
-			<string>../Pods-NYTPhotoViewer-Swift-NYTPhotoViewer/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E0A98A7C6AB18D4103E0D87A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NYTPhotoDismissalInteractionController.m</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotoDismissalInteractionController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E0ED2EDB9A6415A056DE5CFB</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>A3C38321E78A8DD16837EC35</string>
-			<key>buildPhases</key>
-			<array>
-				<string>DFF18B0468F16A6093E25876</string>
-				<string>F28E2AFACDB161074E8DEEE3</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>99C41C502164EF6C5DDCB7AE</string>
-				<string>44CEC4D954815E90731BFC57</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-Tests</string>
-			<key>productName</key>
-			<string>Pods-Tests</string>
-			<key>productReference</key>
-			<string>3B934FCE1F8716091A32FE81</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>E0F9E06D4BD660FA010FF66E</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2176793C28BC562FDAE85D3F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>E10ACCFC67198E49FA479F63</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-Tests.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E1FCC4F652AA3FDA50D64379</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-NYTPhotoViewer.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E20E6ECED2388FC746048E77</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8A71387381A723E740927E59</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E21038FD1FE8F1F406CD098B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1629E9E9F8042A2096E475B3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E2140C737209892D3F8C460F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E2D401B06064CBCBE38FFEF4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E26846BA9A7F6C234C6AFD85</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NSMethodSignature+OCMAdditions.m</string>
-			<key>path</key>
-			<string>Source/OCMock/NSMethodSignature+OCMAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E2D401B06064CBCBE38FFEF4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>NYTPhotoTransitionController.m</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotoTransitionController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E2E4B5C18DCD84D83B675BEF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E39A56283839D595EFECFD90</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC61D2C6034C7A5815BE03F3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E3BC1B85323AEDDC9FF2FEA2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACE8A9A636D7CE6B4411216A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>E3FF72A44A06BE2DE21C2270</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC61D2C6034C7A5815BE03F3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E48EDDF4E40CB5C5ECA925BB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FE7D9F49EDE8F22171327D20</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E5F55694026E98ECD9866856</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BEF933B04E5D228A7A18ADDA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E6DAE5C9B678B75FB1C80454</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-Swift-environment.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E71C3BB6E5CB1528E12A96A3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2739CDA5AB001D7AEFEF9734</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E734218E81D4249D07D22ADC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>85B981625089E45E1C42CDE4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E7B376F0E4E7313B48C9B5FD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A2AA39193DA6E68F7B97B3A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E7BF65213D7FBC77F8FF1363</key>
-		<dict>
-			<key>fileRef</key>
-			<string>87EB1BF6CEA3F1873E4FFA50</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E830C9BDACBD1C723C425830</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B8D7B9932B3747FDA8D1A6FF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>E884CCF2E609A2DF4B799FA1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>33DC27FA73F298AF8E69D7AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E9ACDC7D73AD65931322460C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCObserverMockObject.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCObserverMockObject.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EB03C6769464BB66A4DC65C3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>903209471199CAEE3B42CA19</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EB3F8ABB51CBE9292B3A8E08</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D714BC42AFE98071E83FB55A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EB760647CD2C6D6AF095ECD2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTOperatingSystemCompatibilityUtility.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTOperatingSystemCompatibilityUtility.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC61D2C6034C7A5815BE03F3</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>ECFD0B9B4877B1B42B71F472</key>
-		<dict>
-			<key>fileRef</key>
-			<string>62158E9CABF1BA176E6D4C59</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ED57D537BB3EB8AD68D997C0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CA18D29B4A53538648260D21</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EDE4D8460746F33533829640</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9FB3EC2C4D5F6F924DF2EBBA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EEEA7EBB25EF27D55ABA4FD6</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>DB3F5DC7DE66FB7274E6FB52</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>2104855B84EF13FE632EC212</string>
-			<key>remoteInfo</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-OCMock</string>
-		</dict>
-		<key>EFA58414A5B2F1CBFC1BECAC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTPhotoContainer.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/Protocols/NYTPhotoContainer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F0F1A28D19832F854C732D1E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>07BAB14A5F32DDF1574F2E99</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F13A62CD6E12E5F145564A34</key>
-		<dict>
-			<key>fileRef</key>
-			<string>959C8D3D088313E20DA6AB65</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F13CABD95AF1FEB2271C600E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>Pods-Tests-NYTPhotoViewer-dummy.m</string>
-			<key>path</key>
-			<string>../Pods-Tests-NYTPhotoViewer/Pods-Tests-NYTPhotoViewer-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F19C5AD4A4FA60B998AE3EDE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>65CBB3F80E251AEA9104CB71</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>F1BCFEA54E76501FBCB5E4C4</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>OCMExpectationRecorder.m</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMExpectationRecorder.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F262EA2711B86BFF08D5DA96</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMBoxedReturnValueProvider.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMBoxedReturnValueProvider.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F2877E4932031B6DB35FA0E3</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>2D934C00AA62DB623AA053F1</string>
-			<key>buildPhases</key>
-			<array>
-				<string>3A3E3E8BD2CCF57F7617CC42</string>
-				<string>E0F9E06D4BD660FA010FF66E</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>299B3FFF8FBAB1C3DBCE9236</string>
-				<string>CCE66B93D04970FE98EA21DC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests</string>
-			<key>productName</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests</string>
-			<key>productReference</key>
-			<string>806A3C92AC1C8976713B07B4</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>F28E2AFACDB161074E8DEEE3</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>19E8A25A23F1C3B97D1B7CD2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F2A7FC568E8088E471D860EE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2DDA1EE2FA4741E1C1A57FAB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>F2AB71D4DAF54BFD1B1FA44E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9DB501DA0B2A3723253C024C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F2BE408A7422AFE4DE7B67E2</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-NYTPhotoViewer-Swift-NYTPhotoViewer.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-NYTPhotoViewer-Swift-NYTPhotoViewer/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F2D49A50BCDAB974F67D4CF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5F6CBF3D584CD42B55AEB1DF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F39AA576F184D8F21C72C46A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>85B981625089E45E1C42CDE4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F3CDC348008DF5B1BB750686</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4D9C87316D51A3019812E812</string>
-				<string>C32125E4A6AF66AA52B71B95</string>
-				<string>781B44CA573D65EFEDB7ED86</string>
-				<string>292D2375F2BD26E146CDD68D</string>
-				<string>6B058507325AC4344802BBCE</string>
-				<string>C52ABCCFDD6F6C846C66BC06</string>
-				<string>D3E3AEE239D58900B1A098AB</string>
-				<string>54E7CC5695D31BC468B4689E</string>
-				<string>918FD1D39CB234CB639D33EC</string>
-				<string>88FFB8E8CE680E58AE696CD7</string>
-				<string>F7573D629803B18E179098C1</string>
-				<string>FACF10EE9495312E24A39A24</string>
-				<string>25A6643BB2363320A15111E8</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F4419E858FEA7948D6AE7CFF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-environment.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F4E78FC4A2B44F075EAE31FA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-Swift-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F5BB7526AE1EB62A063D4BB7</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>DB3F5DC7DE66FB7274E6FB52</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>DACEF04843F4D3AAB41E45B9</string>
-			<key>remoteInfo</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer</string>
-		</dict>
-		<key>F6AF54630700F5E9C5C2CC7D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC9878B540D77AA436459189</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F6E67ADB8E8582FDA08A8CBC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-SwiftTests.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F7573D629803B18E179098C1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>62158E9CABF1BA176E6D4C59</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7E5179949F07ED158C3C824</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C3238309106D63A91FE528C9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7EF061A03591B3255B1B664</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F13CABD95AF1FEB2271C600E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F824173726541D181A9D00F3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8C98F7877C29008627A2D842</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F8846770DB6FA58A8155EE1B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-Tests-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F8D52EC26C2F32AAA5DFA3B2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4D5AFE219FE801BFEBAD7183</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F9D571D2B40CA5A4BF7C7E69</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6492E956F099D5E6817648BA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FA3488EC2BDD028C8EB901C0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMReturnValueProvider.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMReturnValueProvider.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FACF10EE9495312E24A39A24</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A2AA39193DA6E68F7B97B3A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FAD8B38EA65866441107E950</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E031EE8F4B8D8A72CCBB2B85</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>FB47254A4055AE3C774C5CF8</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>DBAF899A63B79796E5009645</string>
-			<key>buildPhases</key>
-			<array>
-				<string>1D424E9C9915DD35D0596789</string>
-				<string>161E063BBEF3983A7CCF5C34</string>
-				<string>9A6B20E0E7794E652E5306DA</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-Tests-OCMock</string>
-			<key>productName</key>
-			<string>Pods-Tests-OCMock</string>
-			<key>productReference</key>
-			<string>75E0863BEC7C298CA54E0C41</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>FB8D122E5026B28059C55574</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>38622758EBC4096408358F2A</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>FBA5E233A118EFFE1233BD71</key>
-		<dict>
-			<key>fileRef</key>
-			<string>918AC8496C7782C8A3A27FD8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FC05C962D1CFA81F0AD78A33</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>OCMRealObjectForwarder.h</string>
-			<key>path</key>
-			<string>Source/OCMock/OCMRealObjectForwarder.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FD81BE22F42799FEA42A0ADD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9F58613E0A68B64D461E3280</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FDDAB3E5CB605CC4BA09C1AF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-NYTPhotoViewer-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FE1595AC8EBB317AA93524E4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>130B84B5FC7EDFBA3CF03BD8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>FE7D9F49EDE8F22171327D20</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>NYTPhotosDataSource.h</string>
-			<key>path</key>
-			<string>Pod/Classes/ios/NYTPhotosDataSource.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>DB3F5DC7DE66FB7274E6FB52</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		015E0414AD24281005E5750C /* OCMExceptionReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 856456FA1A25692FEFC3FE28 /* OCMExceptionReturnValueProvider.h */; };
+		0164B49DEBF3FD09112BAF54 /* OCMBoxedReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = F262EA2711B86BFF08D5DA96 /* OCMBoxedReturnValueProvider.h */; };
+		04D5496729A0A1C3E445CCC5 /* OCMBlockCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 8647301F5C968345D6C65BB3 /* OCMBlockCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		05066F08A4081B2ADC64BFD6 /* OCPartialMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = B2926136463FFA4168502AA1 /* OCPartialMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		056829D68A120794CCC55FB1 /* NYTPhotoDismissalInteractionController.m in Sources */ = {isa = PBXBuildFile; fileRef = E0A98A7C6AB18D4103E0D87A /* NYTPhotoDismissalInteractionController.m */; };
+		06DA2E7E2D69F82C0A3DA20C /* NYTPhotoTransitionController.h in Headers */ = {isa = PBXBuildFile; fileRef = B9D0611732608546131C68AB /* NYTPhotoTransitionController.h */; };
+		0B77D3608D09516179FFEDC8 /* OCMExpectationRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C15D35E2817745B63904821 /* OCMExpectationRecorder.h */; };
+		0CBCEC4163FB3ADE88A24B80 /* NYTOperatingSystemCompatibilityUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = EB760647CD2C6D6AF095ECD2 /* NYTOperatingSystemCompatibilityUtility.h */; };
+		0E763D8CB6064F5D1EFF7599 /* OCMReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4233DAABFADA2023EB350D79 /* OCMReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		0F5F94B5A5F9332D4C8A32C9 /* OCPartialMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = B2926136463FFA4168502AA1 /* OCPartialMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		0F7D347C6001BA07836F5F26 /* OCMPassByRefSetter.m in Sources */ = {isa = PBXBuildFile; fileRef = 46A58C3669B50A2A63A8C185 /* OCMPassByRefSetter.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		118F763BC48FEFB7DFA68BF4 /* OCMLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D8AC5A109BD394BDE891454 /* OCMLocation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		12CF97F49B80D0A051FE1DB0 /* OCMArg.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AA001EFA3696F3A3ECC1C5A /* OCMArg.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		139760EB2F3134E3C8A0510C /* OCObserverMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = E9ACDC7D73AD65931322460C /* OCObserverMockObject.h */; };
+		14C54B648E45B84FB7ADF9D4 /* OCMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 38E5FA1FF570E28DB4310AFF /* OCMock.h */; };
+		151D006F83A16AB3332DB9CC /* NYTPhotoDismissalInteractionController.m in Sources */ = {isa = PBXBuildFile; fileRef = E0A98A7C6AB18D4103E0D87A /* NYTPhotoDismissalInteractionController.m */; };
+		152A783F03F3584D6CF20251 /* OCMBoxedReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = F262EA2711B86BFF08D5DA96 /* OCMBoxedReturnValueProvider.h */; };
+		16DB23E61ADCB20BC55D5D13 /* NYTPhotoTransitionController.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D401B06064CBCBE38FFEF4 /* NYTPhotoTransitionController.m */; };
+		183BB060A9ADD0F503B6B2DA /* NYTPhotosViewControllerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A2AA39193DA6E68F7B97B3A0 /* NYTPhotosViewControllerDataSource.h */; };
+		19E8A25A23F1C3B97D1B7CD2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85B981625089E45E1C42CDE4 /* Foundation.framework */; };
+		1A1DE934D733864D4FEEA162 /* OCMInvocationExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0173576ECF18C2B5B84DA883 /* OCMInvocationExpectation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1A5CE29D7708C2092B5F0082 /* OCMLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 1944CBEDD7EB3F42ABB7035D /* OCMLocation.h */; };
+		1B53F2FDEF2057318516A931 /* OCClassMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 87264381DE7CA6CDF3B56575 /* OCClassMockObject.h */; };
+		1B588B1D79BF7E420074A990 /* OCMLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 1944CBEDD7EB3F42ABB7035D /* OCMLocation.h */; };
+		1E35AE8BC3084101DDD5EE82 /* NYTOperatingSystemCompatibilityUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F58613E0A68B64D461E3280 /* NYTOperatingSystemCompatibilityUtility.m */; };
+		2176793C28BC562FDAE85D3F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85B981625089E45E1C42CDE4 /* Foundation.framework */; };
+		21A88F51F216B0659EB3B76A /* Pods-NYTPhotoViewer-SwiftTests-OCMock-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D3585DE44F744998B63E2F8E /* Pods-NYTPhotoViewer-SwiftTests-OCMock-dummy.m */; };
+		22A1B39DABC21B6183F22CCB /* OCMReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = FA3488EC2BDD028C8EB901C0 /* OCMReturnValueProvider.h */; };
+		2561273CB0CA8D9EA96CD557 /* NYTPhotoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C98F7877C29008627A2D842 /* NYTPhotoViewController.m */; };
+		25A6643BB2363320A15111E8 /* NYTScalingImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DD26D85E326E913CEE025D8 /* NYTScalingImageView.h */; };
+		25CD1295ABE755C4EA757857 /* OCMObserverRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = CABBA1BAA3054F876B0C8F01 /* OCMObserverRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		26DCE245D3925CEB3A8D0FDB /* OCMConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 2739CDA5AB001D7AEFEF9734 /* OCMConstraint.h */; };
+		278F689B521DD0D500FE4F99 /* NYTPhotosOverlayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 45FB9190CA97B941207A4630 /* NYTPhotosOverlayView.m */; };
+		292D2375F2BD26E146CDD68D /* NYTPhotoContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = EFA58414A5B2F1CBFC1BECAC /* NYTPhotoContainer.h */; };
+		2A0999B262595827E16E7A01 /* NYTPhotoTransitionController.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D401B06064CBCBE38FFEF4 /* NYTPhotoTransitionController.m */; };
+		2A1225DA14A462FFEF175AB9 /* NYTOperatingSystemCompatibilityUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F58613E0A68B64D461E3280 /* NYTOperatingSystemCompatibilityUtility.m */; };
+		2A81BD101B56F91100EE971C /* NYTPhotoViewer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A81BD0F1B56F91100EE971C /* NYTPhotoViewer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A81BD161B56F91100EE971C /* NYTPhotoViewer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A81BD0B1B56F91100EE971C /* NYTPhotoViewer.framework */; };
+		2A81BD1D1B56F91100EE971C /* NYTPhotoViewerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A81BD1C1B56F91100EE971C /* NYTPhotoViewerTests.m */; };
+		2A81BD241B56F91E00EE971C /* NYTOperatingSystemCompatibilityUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = EB760647CD2C6D6AF095ECD2 /* NYTOperatingSystemCompatibilityUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A81BD251B56F91E00EE971C /* NYTOperatingSystemCompatibilityUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F58613E0A68B64D461E3280 /* NYTOperatingSystemCompatibilityUtility.m */; };
+		2A81BD261B56F91E00EE971C /* NYTPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 1629E9E9F8042A2096E475B3 /* NYTPhoto.h */; };
+		2A81BD271B56F91E00EE971C /* NYTPhotoCaptionView.h in Headers */ = {isa = PBXBuildFile; fileRef = BEF933B04E5D228A7A18ADDA /* NYTPhotoCaptionView.h */; };
+		2A81BD281B56F91E00EE971C /* NYTPhotoCaptionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 33DC27FA73F298AF8E69D7AB /* NYTPhotoCaptionView.m */; };
+		2A81BD291B56F91E00EE971C /* NYTPhotoContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = EFA58414A5B2F1CBFC1BECAC /* NYTPhotoContainer.h */; };
+		2A81BD2A1B56F91E00EE971C /* NYTPhotoDismissalInteractionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B2915B5408DB212F1A872B0 /* NYTPhotoDismissalInteractionController.h */; };
+		2A81BD2B1B56F91E00EE971C /* NYTPhotoDismissalInteractionController.m in Sources */ = {isa = PBXBuildFile; fileRef = E0A98A7C6AB18D4103E0D87A /* NYTPhotoDismissalInteractionController.m */; };
+		2A81BD2C1B56F91E00EE971C /* NYTPhotoTransitionAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = AC9878B540D77AA436459189 /* NYTPhotoTransitionAnimator.h */; };
+		2A81BD2D1B56F91E00EE971C /* NYTPhotoTransitionAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 903209471199CAEE3B42CA19 /* NYTPhotoTransitionAnimator.m */; };
+		2A81BD2E1B56F91E00EE971C /* NYTPhotoTransitionController.h in Headers */ = {isa = PBXBuildFile; fileRef = B9D0611732608546131C68AB /* NYTPhotoTransitionController.h */; };
+		2A81BD2F1B56F91E00EE971C /* NYTPhotoTransitionController.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D401B06064CBCBE38FFEF4 /* NYTPhotoTransitionController.m */; };
+		2A81BD301B56F91E00EE971C /* NYTPhotoViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9075BF902932F4D3B5717B4E /* NYTPhotoViewController.h */; };
+		2A81BD311B56F91E00EE971C /* NYTPhotoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C98F7877C29008627A2D842 /* NYTPhotoViewController.m */; };
+		2A81BD321B56F91E00EE971C /* NYTPhotosDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7D9F49EDE8F22171327D20 /* NYTPhotosDataSource.h */; };
+		2A81BD331B56F91E00EE971C /* NYTPhotosDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = D714BC42AFE98071E83FB55A /* NYTPhotosDataSource.m */; };
+		2A81BD341B56F91E00EE971C /* NYTPhotosOverlayView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCE4C4A3CC66AFA2646C365C /* NYTPhotosOverlayView.h */; };
+		2A81BD351B56F91E00EE971C /* NYTPhotosOverlayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 45FB9190CA97B941207A4630 /* NYTPhotosOverlayView.m */; };
+		2A81BD361B56F91E00EE971C /* NYTPhotosViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 62158E9CABF1BA176E6D4C59 /* NYTPhotosViewController.h */; };
+		2A81BD371B56F91E00EE971C /* NYTPhotosViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 87EB1BF6CEA3F1873E4FFA50 /* NYTPhotosViewController.m */; };
+		2A81BD381B56F91E00EE971C /* NYTPhotosViewControllerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A2AA39193DA6E68F7B97B3A0 /* NYTPhotosViewControllerDataSource.h */; };
+		2A81BD391B56F91E00EE971C /* NYTScalingImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DD26D85E326E913CEE025D8 /* NYTScalingImageView.h */; };
+		2A81BD3A1B56F91E00EE971C /* NYTScalingImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = B9164895990534371A09C187 /* NYTScalingImageView.m */; };
+		2AB8C29105D31E289D65839B /* OCMExceptionReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 856456FA1A25692FEFC3FE28 /* OCMExceptionReturnValueProvider.h */; };
+		2ABC4C2AE43F6DAD3A642F57 /* NYTPhotoViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9075BF902932F4D3B5717B4E /* NYTPhotoViewController.h */; };
+		2B251A189EC557DDDDDA469E /* NYTPhotosViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 87EB1BF6CEA3F1873E4FFA50 /* NYTPhotosViewController.m */; };
+		2C05312A1C90F8175B932164 /* NYTScalingImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = B9164895990534371A09C187 /* NYTScalingImageView.m */; };
+		2CC43C113F8A24E48629AC04 /* Pods-NYTPhotoViewer-NYTPhotoViewer-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B12F9AC1F97C4FE18FA0DD03 /* Pods-NYTPhotoViewer-NYTPhotoViewer-dummy.m */; };
+		2F54BB8FA3B465875CA7D6F7 /* OCMVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = CA18D29B4A53538648260D21 /* OCMVerifier.h */; };
+		2F8AA59CA858EB5DA740B810 /* OCMRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = C3238309106D63A91FE528C9 /* OCMRecorder.h */; };
+		2FCC37CD4A39646933819732 /* OCMExpectationRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C15D35E2817745B63904821 /* OCMExpectationRecorder.h */; };
+		323B0BCDA6BE5B1ACBCE77AD /* NSMethodSignature+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = E26846BA9A7F6C234C6AFD85 /* NSMethodSignature+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		32C7B0E6AF799371FE62B0D5 /* NYTPhotoCaptionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 33DC27FA73F298AF8E69D7AB /* NYTPhotoCaptionView.m */; };
+		32CD52FD28A787B9FE09E9F4 /* NYTPhotoCaptionView.h in Headers */ = {isa = PBXBuildFile; fileRef = BEF933B04E5D228A7A18ADDA /* NYTPhotoCaptionView.h */; };
+		36B833681C4F076BF56FCEBB /* OCMStubRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BC5A9D64F89FE7331C73A3 /* OCMStubRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		36C743ADC61B5F76231EE2BC /* NYTPhotosDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = D714BC42AFE98071E83FB55A /* NYTPhotosDataSource.m */; };
+		3772E7EEE6AB6D00D9F331AB /* OCMFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9846BBCE91D248C6CBDC83C1 /* OCMFunctions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		37A004E5CFC5AA9A094FD1C5 /* NYTPhotosOverlayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 45FB9190CA97B941207A4630 /* NYTPhotosOverlayView.m */; };
+		37F8EDFD997F8B953C6B679A /* OCMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 44800019A7D1F62A409C02AB /* OCMockObject.h */; };
+		39870B1D6DB0C778CBF6D749 /* NYTPhotosViewControllerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A2AA39193DA6E68F7B97B3A0 /* NYTPhotosViewControllerDataSource.h */; };
+		3A344E6D9333FED65A6300C8 /* OCMObserverRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = CABBA1BAA3054F876B0C8F01 /* OCMObserverRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		3B0D1B05A7A7796A3CB8ED8F /* NSObject+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 751F2F2940E6C6148A62FAC6 /* NSObject+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		3CC92C10E7DBA6CBF22A489F /* OCPartialMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A7885EBD8438F61F0BBF5DEE /* OCPartialMockObject.h */; };
+		3D17549A57BFCE5295C87035 /* OCMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 49E0C917D1519C6A9446AD9E /* OCMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		3DB3A1DF322DB3431EA27904 /* OCMMacroState.m in Sources */ = {isa = PBXBuildFile; fileRef = 68C7BA95CF440E9D0687A898 /* OCMMacroState.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		3F85EA81252940DEB00FC1FC /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DF020583EE6DD060F87A029 /* NSValue+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		40C977BD65720FB89A08A869 /* OCMBlockCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = 307DC766F062DA6F22E0A8C2 /* OCMBlockCaller.h */; };
+		41A2D01B9AE6B55D4CB54B89 /* OCMInvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DB501DA0B2A3723253C024C /* OCMInvocationMatcher.h */; };
+		43399EC15351453AE666AECD /* OCMExceptionReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A2EFE1FDE8C273E41FBFCF5 /* OCMExceptionReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		438A1D6371FE2E2DFF76093A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85B981625089E45E1C42CDE4 /* Foundation.framework */; };
+		43C3CE9C3E3BC3BE4E3A1E16 /* OCClassMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 87264381DE7CA6CDF3B56575 /* OCClassMockObject.h */; };
+		4570C9B61E0DA14C7E9C319B /* NYTScalingImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DD26D85E326E913CEE025D8 /* NYTScalingImageView.h */; };
+		46E6EFF02357FC93AF696272 /* OCMInvocationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AAA1B247A4A215F7A5907E3 /* OCMInvocationMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		4807A4121C26FE5BBFB5BBDB /* OCObserverMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = E9ACDC7D73AD65931322460C /* OCObserverMockObject.h */; };
+		49DE14448904B4D3FBDE54A6 /* OCMInvocationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2569F5D65FEFD9942A27325B /* OCMInvocationExpectation.h */; };
+		4D59AED6FC23CA17EA99640F /* NYTPhotosViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 87EB1BF6CEA3F1873E4FFA50 /* NYTPhotosViewController.m */; };
+		4D84B0B1828FF9F17EAE72CF /* NSNotificationCenter+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 34B5CAE55D0AED1F4718B537 /* NSNotificationCenter+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		4D9C87316D51A3019812E812 /* NYTOperatingSystemCompatibilityUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = EB760647CD2C6D6AF095ECD2 /* NYTOperatingSystemCompatibilityUtility.h */; };
+		4F27CB1D26F356F78CFD3D06 /* Pods-NYTPhotoViewer-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 22048393DB660082285AF393 /* Pods-NYTPhotoViewer-dummy.m */; };
+		4F69D2808E42983BA8814A4B /* NYTPhotosViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 62158E9CABF1BA176E6D4C59 /* NYTPhotosViewController.h */; };
+		51091C5B419F91900ED19FB5 /* NYTPhotoDismissalInteractionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B2915B5408DB212F1A872B0 /* NYTPhotoDismissalInteractionController.h */; };
+		5236B10EF0CBE94BF253E91A /* NYTPhotosOverlayView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCE4C4A3CC66AFA2646C365C /* NYTPhotosOverlayView.h */; };
+		54E7CC5695D31BC468B4689E /* NYTPhotoViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9075BF902932F4D3B5717B4E /* NYTPhotoViewController.h */; };
+		55D054D2215886D0B1033FED /* OCMBlockCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 8647301F5C968345D6C65BB3 /* OCMBlockCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		56C60D5C34B45096E13A4ABE /* NYTOperatingSystemCompatibilityUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = EB760647CD2C6D6AF095ECD2 /* NYTOperatingSystemCompatibilityUtility.h */; };
+		58CC19214E17AD160D44D4DD /* NYTPhotoTransitionAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 903209471199CAEE3B42CA19 /* NYTPhotoTransitionAnimator.m */; };
+		59865BA3CD478F735ABC11FC /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E60F98A792FD711A9EBB79B /* NSInvocation+OCMAdditions.h */; };
+		59C9858A15A458265D64BEEF /* OCMArg.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AA001EFA3696F3A3ECC1C5A /* OCMArg.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		5AF80A29F00DCD3525E738E7 /* OCProtocolMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 743F48CD04F7E076541BFC47 /* OCProtocolMockObject.h */; };
+		5E6E75B60A5A6C24DC969089 /* OCMStubRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 3713D32BDA852095EA2A73DE /* OCMStubRecorder.h */; };
+		601C21199EE2C1DFA1BCB15C /* OCMStubRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BC5A9D64F89FE7331C73A3 /* OCMStubRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		607AF39C3A9F35E619C2C5C2 /* NYTPhotoCaptionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 33DC27FA73F298AF8E69D7AB /* NYTPhotoCaptionView.m */; };
+		623099A9AF2218F7FF4A697D /* NYTOperatingSystemCompatibilityUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = EB760647CD2C6D6AF095ECD2 /* NYTOperatingSystemCompatibilityUtility.h */; };
+		62EEDDBF2AA6D86E983BF726 /* NSNotificationCenter+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B02D56495BF8A566E8EA6AD /* NSNotificationCenter+OCMAdditions.h */; };
+		636F3908B0DF40628CA7D3F8 /* OCMRealObjectForwarder.h in Headers */ = {isa = PBXBuildFile; fileRef = FC05C962D1CFA81F0AD78A33 /* OCMRealObjectForwarder.h */; };
+		64F4BC5C2509CE1E037C55C2 /* OCMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 38E5FA1FF570E28DB4310AFF /* OCMock.h */; };
+		663FEDC2F9ED56FA60E637DD /* OCMNotificationPoster.h in Headers */ = {isa = PBXBuildFile; fileRef = 49A80A0AD117B07B14D521F5 /* OCMNotificationPoster.h */; };
+		6739E028DAF5E977D978AB7A /* NSNotificationCenter+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 34B5CAE55D0AED1F4718B537 /* NSNotificationCenter+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		681441754AB5D7DF127B43C4 /* OCMExpectationRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = F1BCFEA54E76501FBCB5E4C4 /* OCMExpectationRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		689FDA306464A152F43FD1F5 /* OCMExpectationRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = F1BCFEA54E76501FBCB5E4C4 /* OCMExpectationRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		6B058507325AC4344802BBCE /* NYTPhotoDismissalInteractionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B2915B5408DB212F1A872B0 /* NYTPhotoDismissalInteractionController.h */; };
+		6B1C3F40818CBFA16DF95C09 /* NYTPhotosViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 62158E9CABF1BA176E6D4C59 /* NYTPhotosViewController.h */; };
+		6BC0C426D4F00674C04F48E0 /* OCPartialMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A7885EBD8438F61F0BBF5DEE /* OCPartialMockObject.h */; };
+		6D9AEF14DBBDA0549E60E96B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85B981625089E45E1C42CDE4 /* Foundation.framework */; };
+		6ED37D4D6BF570E74AFE83F7 /* Pods-Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C381950D67F1AE46264A6AF8 /* Pods-Tests-dummy.m */; };
+		6EEBAFE78B2CF2AF801D6733 /* NYTPhotoDismissalInteractionController.m in Sources */ = {isa = PBXBuildFile; fileRef = E0A98A7C6AB18D4103E0D87A /* NYTPhotoDismissalInteractionController.m */; };
+		70548ECADB5332269E65AF4C /* NYTPhotoDismissalInteractionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B2915B5408DB212F1A872B0 /* NYTPhotoDismissalInteractionController.h */; };
+		70AA19CBF91B6EC6A634A222 /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E60F98A792FD711A9EBB79B /* NSInvocation+OCMAdditions.h */; };
+		70B6FBBC064CC361AB24C0DA /* NYTPhotoContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = EFA58414A5B2F1CBFC1BECAC /* NYTPhotoContainer.h */; };
+		738FD3CA96D7B232D196DF3D /* OCMVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 65CBB3F80E251AEA9104CB71 /* OCMVerifier.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		7565230DB6A9620A1B094C7A /* NSInvocation+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DE9BD92CACFDFD7DE3D8533B /* NSInvocation+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		760590D187902346DB2BCFC9 /* NYTPhotoTransitionController.h in Headers */ = {isa = PBXBuildFile; fileRef = B9D0611732608546131C68AB /* NYTPhotoTransitionController.h */; };
+		780B3D1D92E1C2E92E6C1B6B /* OCMPassByRefSetter.m in Sources */ = {isa = PBXBuildFile; fileRef = 46A58C3669B50A2A63A8C185 /* OCMPassByRefSetter.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		781B44CA573D65EFEDB7ED86 /* NYTPhotoCaptionView.h in Headers */ = {isa = PBXBuildFile; fileRef = BEF933B04E5D228A7A18ADDA /* NYTPhotoCaptionView.h */; };
+		7830C2949BA1CB606CEF70CE /* OCMMacroState.m in Sources */ = {isa = PBXBuildFile; fileRef = 68C7BA95CF440E9D0687A898 /* OCMMacroState.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		7968FC48DFDA1B3785F73F4B /* OCMLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D8AC5A109BD394BDE891454 /* OCMLocation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		7B54D14A71AB5B0F16465842 /* NYTPhotosOverlayView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCE4C4A3CC66AFA2646C365C /* NYTPhotosOverlayView.h */; };
+		7DCF3F784593A0129B36C179 /* NYTPhotoContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = EFA58414A5B2F1CBFC1BECAC /* NYTPhotoContainer.h */; };
+		7E16BF7E80E66C9BAA600481 /* OCMRealObjectForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = 69F0FC0376CE26BC3950F5B0 /* OCMRealObjectForwarder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		7EB9E346E3DA38232A849273 /* NYTPhotoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C98F7877C29008627A2D842 /* NYTPhotoViewController.m */; };
+		7F1B41130A03CDC9789CDEDE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85B981625089E45E1C42CDE4 /* Foundation.framework */; };
+		808E08A0BA8F7D4F170C35FE /* OCMInvocationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AAA1B247A4A215F7A5907E3 /* OCMInvocationMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		8229F2538A10468699323314 /* Pods-NYTPhotoViewer-SwiftTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB01BCB2E5807A82F681E7 /* Pods-NYTPhotoViewer-SwiftTests-dummy.m */; };
+		874CCF36599385E29622AC1E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85B981625089E45E1C42CDE4 /* Foundation.framework */; };
+		878568BFE16D81A4A00DD87A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC61D2C6034C7A5815BE03F3 /* UIKit.framework */; };
+		87D7512B79AA4C9ECA874EB2 /* OCMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 44800019A7D1F62A409C02AB /* OCMockObject.h */; };
+		88FFB8E8CE680E58AE696CD7 /* NYTPhotosOverlayView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCE4C4A3CC66AFA2646C365C /* NYTPhotosOverlayView.h */; };
+		89FB1B1782E6BFD561C3CD14 /* NSValue+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FF2A0F71C89297574749F2C /* NSValue+OCMAdditions.h */; };
+		8B8D98DF6B861C3866837A92 /* OCMMacroState.h in Headers */ = {isa = PBXBuildFile; fileRef = B0222A66BB9F7F439575B8F0 /* OCMMacroState.h */; };
+		8EDBA5F0FCBCCED6E39BEEA1 /* NSValue+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FF2A0F71C89297574749F2C /* NSValue+OCMAdditions.h */; };
+		8F204A9D76A8F45D856BE530 /* OCMReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4233DAABFADA2023EB350D79 /* OCMReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		9066D53EDD0479E5742F0631 /* NYTScalingImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DD26D85E326E913CEE025D8 /* NYTScalingImageView.h */; };
+		9073322179745DC90D4B1394 /* Pods-NYTPhotoViewer-Swift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F4E78FC4A2B44F075EAE31FA /* Pods-NYTPhotoViewer-Swift-dummy.m */; };
+		909C6DB1829CB8D53D6B5BE9 /* NYTScalingImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = B9164895990534371A09C187 /* NYTScalingImageView.m */; };
+		916E3295F81C6B45837EC1F2 /* OCMFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9846BBCE91D248C6CBDC83C1 /* OCMFunctions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		91824627BDD99B2A2A6C3C99 /* OCMMacroState.h in Headers */ = {isa = PBXBuildFile; fileRef = B0222A66BB9F7F439575B8F0 /* OCMMacroState.h */; };
+		918FD1D39CB234CB639D33EC /* NYTPhotosDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7D9F49EDE8F22171327D20 /* NYTPhotosDataSource.h */; };
+		9231A601A6094B3BBBB3C1B1 /* OCMNotificationPoster.m in Sources */ = {isa = PBXBuildFile; fileRef = B8D7B9932B3747FDA8D1A6FF /* OCMNotificationPoster.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		93188388DFD83F2E61EC26E8 /* NYTOperatingSystemCompatibilityUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F58613E0A68B64D461E3280 /* NYTOperatingSystemCompatibilityUtility.m */; };
+		94076555791A8A5E89ACC230 /* OCMInvocationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2569F5D65FEFD9942A27325B /* OCMInvocationExpectation.h */; };
+		948C084D5D6EF42AF89FB510 /* OCMFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F8A19FB9F12A9464B8E14ED /* OCMFunctions.h */; };
+		976E372E2004153FD3F85890 /* NYTPhotoViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9075BF902932F4D3B5717B4E /* NYTPhotoViewController.h */; };
+		99EDE1F605E9270D670B70C1 /* NYTPhotoCaptionView.h in Headers */ = {isa = PBXBuildFile; fileRef = BEF933B04E5D228A7A18ADDA /* NYTPhotoCaptionView.h */; };
+		9A1BC8AF7009E227336CD76E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85B981625089E45E1C42CDE4 /* Foundation.framework */; };
+		9A1D8FF3FECAE266DF1919F9 /* NSObject+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71387381A723E740927E59 /* NSObject+OCMAdditions.h */; };
+		9A3F5151AC6022733CA55E91 /* OCMIndirectReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CCF7FB922A90B100BF3A650 /* OCMIndirectReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		9B9C54F6E71DF765B769FF6A /* NSInvocation+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DE9BD92CACFDFD7DE3D8533B /* NSInvocation+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		9D9A5BBD65D25652683834AC /* NSObject+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 751F2F2940E6C6148A62FAC6 /* NSObject+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		9E635BC1289151E5254E4293 /* NYTPhotosViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 87EB1BF6CEA3F1873E4FFA50 /* NYTPhotosViewController.m */; };
+		9F2E72395D58FAE18BA21DA7 /* NYTPhotoTransitionController.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D401B06064CBCBE38FFEF4 /* NYTPhotoTransitionController.m */; };
+		A0BE4398BA32F3162D9D6562 /* OCObserverMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F7F25301AED7A40B5D2CF06 /* OCObserverMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A1988ACB88F28CCC5823DFBE /* OCMBoxedReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DDA1EE2FA4741E1C1A57FAB /* OCMBoxedReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A260D88C2C987B8BD4191BA5 /* OCMRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 684EFA81CC3B62CAF710A4D7 /* OCMRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A308017BF4CCA6DC097E201A /* NYTPhotosOverlayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 45FB9190CA97B941207A4630 /* NYTPhotosOverlayView.m */; };
+		A4CFAA11A09B96994A21D71B /* OCProtocolMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 130B84B5FC7EDFBA3CF03BD8 /* OCProtocolMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		AA8E4B00B7D93C4345BDBC03 /* NYTPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 1629E9E9F8042A2096E475B3 /* NYTPhoto.h */; };
+		AB2D2BDDCB26DB31EADE1EA4 /* NYTPhotoTransitionAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = AC9878B540D77AA436459189 /* NYTPhotoTransitionAnimator.h */; };
+		ACEE50D48728EEB5F8354922 /* OCMFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F8A19FB9F12A9464B8E14ED /* OCMFunctions.h */; };
+		AE3D542786E8E1FF3ADACDE1 /* NYTPhotoTransitionAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = AC9878B540D77AA436459189 /* NYTPhotoTransitionAnimator.h */; };
+		AEE254640D562C309A321B2E /* OCMExceptionReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A2EFE1FDE8C273E41FBFCF5 /* OCMExceptionReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B03A7AADC52213AF71F0EDC6 /* OCMConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = ACE8A9A636D7CE6B4411216A /* OCMConstraint.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B1BE80CC0876C7C8D948CC30 /* OCMStubRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 3713D32BDA852095EA2A73DE /* OCMStubRecorder.h */; };
+		B22382FAC747585AFC66A1A0 /* NYTPhotoViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9075BF902932F4D3B5717B4E /* NYTPhotoViewController.h */; };
+		B337DC4CDE59F58D6651F43D /* OCObserverMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F7F25301AED7A40B5D2CF06 /* OCObserverMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B44CD330DF715C17F797AA32 /* OCClassMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = E031EE8F4B8D8A72CCBB2B85 /* OCClassMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B55134BD22538F5C7D0AACBD /* NYTPhotosOverlayView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCE4C4A3CC66AFA2646C365C /* NYTPhotosOverlayView.h */; };
+		B5C4557DF08FC40123B38F31 /* OCMInvocationStub.m in Sources */ = {isa = PBXBuildFile; fileRef = B9259EA232551DA556BEF6BC /* OCMInvocationStub.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B7FC7819993344BCA62B186E /* NYTPhotoDismissalInteractionController.m in Sources */ = {isa = PBXBuildFile; fileRef = E0A98A7C6AB18D4103E0D87A /* NYTPhotoDismissalInteractionController.m */; };
+		B8ECEB7C3984D842060812B7 /* NYTPhotosOverlayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 45FB9190CA97B941207A4630 /* NYTPhotosOverlayView.m */; };
+		BABDAC7DF5EC609B14B5E411 /* NYTScalingImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = B9164895990534371A09C187 /* NYTScalingImageView.m */; };
+		BAC56D667FF286D6330E4FE0 /* OCMIndirectReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 07BAB14A5F32DDF1574F2E99 /* OCMIndirectReturnValueProvider.h */; };
+		BACF355C620F956C3380C7D6 /* NYTPhotoDismissalInteractionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B2915B5408DB212F1A872B0 /* NYTPhotoDismissalInteractionController.h */; };
+		BC5143A55B56BDE2D80E6A12 /* NSMethodSignature+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = E26846BA9A7F6C234C6AFD85 /* NSMethodSignature+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BC70C00E99E3001779951F4F /* Pods-Tests-OCMock-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 024111B35564B48AE0023AA9 /* Pods-Tests-OCMock-dummy.m */; };
+		BCF5CF2871A2C6A8BE39E35E /* OCMRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 684EFA81CC3B62CAF710A4D7 /* OCMRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BD575CDF7A4663127252C464 /* NYTPhotosDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = D714BC42AFE98071E83FB55A /* NYTPhotosDataSource.m */; };
+		BDB99FA97F7D612B728DBA1B /* NYTScalingImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DD26D85E326E913CEE025D8 /* NYTScalingImageView.h */; };
+		BED3EC187AD227769E074EF8 /* OCMIndirectReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CCF7FB922A90B100BF3A650 /* OCMIndirectReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BEEB5CDD41FFE788B7B0ADBB /* NYTPhotoContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = EFA58414A5B2F1CBFC1BECAC /* NYTPhotoContainer.h */; };
+		C0433EC9D69288656B8A48D0 /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DF020583EE6DD060F87A029 /* NSValue+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C0549C6ED28303D10857AE69 /* OCMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 49E0C917D1519C6A9446AD9E /* OCMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C0D0820115B685438F44A32B /* OCMRealObjectForwarder.h in Headers */ = {isa = PBXBuildFile; fileRef = FC05C962D1CFA81F0AD78A33 /* OCMRealObjectForwarder.h */; };
+		C11D170EA81F64A153CC4248 /* NSNotificationCenter+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B02D56495BF8A566E8EA6AD /* NSNotificationCenter+OCMAdditions.h */; };
+		C16378DE0EAF98AB527A74BE /* OCMNotificationPoster.h in Headers */ = {isa = PBXBuildFile; fileRef = 49A80A0AD117B07B14D521F5 /* OCMNotificationPoster.h */; };
+		C182E01E0A7EC5A4484C4B41 /* NYTPhotoCaptionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 33DC27FA73F298AF8E69D7AB /* NYTPhotoCaptionView.m */; };
+		C32125E4A6AF66AA52B71B95 /* NYTPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 1629E9E9F8042A2096E475B3 /* NYTPhoto.h */; };
+		C3DD6609296FBEB3E529A01B /* NYTPhotoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C98F7877C29008627A2D842 /* NYTPhotoViewController.m */; };
+		C4C1D864972C9E7744269700 /* OCMBlockCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = 307DC766F062DA6F22E0A8C2 /* OCMBlockCaller.h */; };
+		C4DD9FFBE917BC0D311424FB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC61D2C6034C7A5815BE03F3 /* UIKit.framework */; };
+		C52ABCCFDD6F6C846C66BC06 /* NYTPhotoTransitionAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = AC9878B540D77AA436459189 /* NYTPhotoTransitionAnimator.h */; };
+		C8418D3444A8D2C48151B255 /* OCMArg.h in Headers */ = {isa = PBXBuildFile; fileRef = 918AC8496C7782C8A3A27FD8 /* OCMArg.h */; };
+		C921BC00C737DACBEE8A1920 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85B981625089E45E1C42CDE4 /* Foundation.framework */; };
+		C9600506CAF4F1B41F3C8435 /* NYTPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 1629E9E9F8042A2096E475B3 /* NYTPhoto.h */; };
+		CB6E4EEDCB390C75488510AF /* NYTPhotoTransitionController.h in Headers */ = {isa = PBXBuildFile; fileRef = B9D0611732608546131C68AB /* NYTPhotoTransitionController.h */; };
+		CBA53F104597B700D89B97CE /* NYTPhotosDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = D714BC42AFE98071E83FB55A /* NYTPhotosDataSource.m */; };
+		CD9741B7AE164912BECE1F01 /* OCMPassByRefSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FB3EC2C4D5F6F924DF2EBBA /* OCMPassByRefSetter.h */; };
+		D28B95ECC09DA0CE5B579F77 /* NYTPhotoTransitionAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 903209471199CAEE3B42CA19 /* NYTPhotoTransitionAnimator.m */; };
+		D3E3AEE239D58900B1A098AB /* NYTPhotoTransitionController.h in Headers */ = {isa = PBXBuildFile; fileRef = B9D0611732608546131C68AB /* NYTPhotoTransitionController.h */; };
+		D53D752AF09654956A95CB44 /* NSMethodSignature+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C34EE63F2441725BAE7C1B69 /* NSMethodSignature+OCMAdditions.h */; };
+		D5CD36836C52834E1C11C329 /* OCMObserverRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D5AFE219FE801BFEBAD7183 /* OCMObserverRecorder.h */; };
+		D89EBF50F6B5D580566FEAC5 /* NYTPhotosDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7D9F49EDE8F22171327D20 /* NYTPhotosDataSource.h */; };
+		D8CDD718588A07F65EFC97E3 /* OCMInvocationStub.m in Sources */ = {isa = PBXBuildFile; fileRef = B9259EA232551DA556BEF6BC /* OCMInvocationStub.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		D8EC2EE0938292DEF26EA394 /* NSMethodSignature+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C34EE63F2441725BAE7C1B69 /* NSMethodSignature+OCMAdditions.h */; };
+		D9820C3FB72CA3E883C794B6 /* NYTPhotosDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7D9F49EDE8F22171327D20 /* NYTPhotosDataSource.h */; };
+		DB4D965D38C629A155F92D11 /* OCMRealObjectForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = 69F0FC0376CE26BC3950F5B0 /* OCMRealObjectForwarder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		DC79D46F4D4D676614C38DAA /* OCMReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = FA3488EC2BDD028C8EB901C0 /* OCMReturnValueProvider.h */; };
+		DD68A2A3D11BE1C6A3C0B1C3 /* NYTPhotoTransitionAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 903209471199CAEE3B42CA19 /* NYTPhotoTransitionAnimator.m */; };
+		DDB89B3EFA729D467B4CEC86 /* OCProtocolMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 743F48CD04F7E076541BFC47 /* OCProtocolMockObject.h */; };
+		DE0AC62E6C5E4576E1752919 /* NYTScalingImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = B9164895990534371A09C187 /* NYTScalingImageView.m */; };
+		DF9044770C313D9F1904ACD9 /* OCMInvocationExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0173576ECF18C2B5B84DA883 /* OCMInvocationExpectation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		DFF2FC54C20ADD0E8CF29271 /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FE1180B890870E37CBC1D98 /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-dummy.m */; };
+		E063BC2BB5F0A56E31D6C061 /* OCMInvocationStub.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F6CBF3D584CD42B55AEB1DF /* OCMInvocationStub.h */; };
+		E20E6ECED2388FC746048E77 /* NSObject+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71387381A723E740927E59 /* NSObject+OCMAdditions.h */; };
+		E21038FD1FE8F1F406CD098B /* NYTPhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 1629E9E9F8042A2096E475B3 /* NYTPhoto.h */; };
+		E2140C737209892D3F8C460F /* NYTPhotoTransitionController.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D401B06064CBCBE38FFEF4 /* NYTPhotoTransitionController.m */; };
+		E39A56283839D595EFECFD90 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC61D2C6034C7A5815BE03F3 /* UIKit.framework */; };
+		E3BC1B85323AEDDC9FF2FEA2 /* OCMConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = ACE8A9A636D7CE6B4411216A /* OCMConstraint.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		E3FF72A44A06BE2DE21C2270 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC61D2C6034C7A5815BE03F3 /* UIKit.framework */; };
+		E48EDDF4E40CB5C5ECA925BB /* NYTPhotosDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7D9F49EDE8F22171327D20 /* NYTPhotosDataSource.h */; };
+		E5F55694026E98ECD9866856 /* NYTPhotoCaptionView.h in Headers */ = {isa = PBXBuildFile; fileRef = BEF933B04E5D228A7A18ADDA /* NYTPhotoCaptionView.h */; };
+		E71C3BB6E5CB1528E12A96A3 /* OCMConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 2739CDA5AB001D7AEFEF9734 /* OCMConstraint.h */; };
+		E734218E81D4249D07D22ADC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85B981625089E45E1C42CDE4 /* Foundation.framework */; };
+		E7B376F0E4E7313B48C9B5FD /* NYTPhotosViewControllerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A2AA39193DA6E68F7B97B3A0 /* NYTPhotosViewControllerDataSource.h */; };
+		E7BF65213D7FBC77F8FF1363 /* NYTPhotosViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 87EB1BF6CEA3F1873E4FFA50 /* NYTPhotosViewController.m */; };
+		E830C9BDACBD1C723C425830 /* OCMNotificationPoster.m in Sources */ = {isa = PBXBuildFile; fileRef = B8D7B9932B3747FDA8D1A6FF /* OCMNotificationPoster.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		E884CCF2E609A2DF4B799FA1 /* NYTPhotoCaptionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 33DC27FA73F298AF8E69D7AB /* NYTPhotoCaptionView.m */; };
+		EB03C6769464BB66A4DC65C3 /* NYTPhotoTransitionAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 903209471199CAEE3B42CA19 /* NYTPhotoTransitionAnimator.m */; };
+		EB3F8ABB51CBE9292B3A8E08 /* NYTPhotosDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = D714BC42AFE98071E83FB55A /* NYTPhotosDataSource.m */; };
+		ECFD0B9B4877B1B42B71F472 /* NYTPhotosViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 62158E9CABF1BA176E6D4C59 /* NYTPhotosViewController.h */; };
+		ED57D537BB3EB8AD68D997C0 /* OCMVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = CA18D29B4A53538648260D21 /* OCMVerifier.h */; };
+		EDE4D8460746F33533829640 /* OCMPassByRefSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FB3EC2C4D5F6F924DF2EBBA /* OCMPassByRefSetter.h */; };
+		F0F1A28D19832F854C732D1E /* OCMIndirectReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 07BAB14A5F32DDF1574F2E99 /* OCMIndirectReturnValueProvider.h */; };
+		F13A62CD6E12E5F145564A34 /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 959C8D3D088313E20DA6AB65 /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-dummy.m */; };
+		F19C5AD4A4FA60B998AE3EDE /* OCMVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 65CBB3F80E251AEA9104CB71 /* OCMVerifier.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		F2A7FC568E8088E471D860EE /* OCMBoxedReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DDA1EE2FA4741E1C1A57FAB /* OCMBoxedReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		F2AB71D4DAF54BFD1B1FA44E /* OCMInvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DB501DA0B2A3723253C024C /* OCMInvocationMatcher.h */; };
+		F2D49A50BCDAB974F67D4CF2 /* OCMInvocationStub.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F6CBF3D584CD42B55AEB1DF /* OCMInvocationStub.h */; };
+		F39AA576F184D8F21C72C46A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85B981625089E45E1C42CDE4 /* Foundation.framework */; };
+		F6AF54630700F5E9C5C2CC7D /* NYTPhotoTransitionAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = AC9878B540D77AA436459189 /* NYTPhotoTransitionAnimator.h */; };
+		F7573D629803B18E179098C1 /* NYTPhotosViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 62158E9CABF1BA176E6D4C59 /* NYTPhotosViewController.h */; };
+		F7E5179949F07ED158C3C824 /* OCMRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = C3238309106D63A91FE528C9 /* OCMRecorder.h */; };
+		F7EF061A03591B3255B1B664 /* Pods-Tests-NYTPhotoViewer-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F13CABD95AF1FEB2271C600E /* Pods-Tests-NYTPhotoViewer-dummy.m */; };
+		F824173726541D181A9D00F3 /* NYTPhotoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C98F7877C29008627A2D842 /* NYTPhotoViewController.m */; };
+		F8D52EC26C2F32AAA5DFA3B2 /* OCMObserverRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D5AFE219FE801BFEBAD7183 /* OCMObserverRecorder.h */; };
+		FACF10EE9495312E24A39A24 /* NYTPhotosViewControllerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A2AA39193DA6E68F7B97B3A0 /* NYTPhotosViewControllerDataSource.h */; };
+		FAD8B38EA65866441107E950 /* OCClassMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = E031EE8F4B8D8A72CCBB2B85 /* OCClassMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		FBA5E233A118EFFE1233BD71 /* OCMArg.h in Headers */ = {isa = PBXBuildFile; fileRef = 918AC8496C7782C8A3A27FD8 /* OCMArg.h */; };
+		FD81BE22F42799FEA42A0ADD /* NYTOperatingSystemCompatibilityUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F58613E0A68B64D461E3280 /* NYTOperatingSystemCompatibilityUtility.m */; };
+		FE1595AC8EBB317AA93524E4 /* OCProtocolMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 130B84B5FC7EDFBA3CF03BD8 /* OCProtocolMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		108E73A754727909F32E6567 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB3F5DC7DE66FB7274E6FB52 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5D82D542EF99743A8B00FCE3;
+			remoteInfo = "Pods-NYTPhotoViewer-NYTPhotoViewer";
+		};
+		2A81BD171B56F91100EE971C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB3F5DC7DE66FB7274E6FB52 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2A81BD0A1B56F91100EE971C;
+			remoteInfo = NYTPhotoViewer;
+		};
+		2D126C1BB9864B0106EE5884 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB3F5DC7DE66FB7274E6FB52 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0447139662D4FCA4E4612E05;
+			remoteInfo = "Pods-Tests-NYTPhotoViewer";
+		};
+		456ADE491FA4A185969E5BDD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB3F5DC7DE66FB7274E6FB52 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB47254A4055AE3C774C5CF8;
+			remoteInfo = "Pods-Tests-OCMock";
+		};
+		648B76D2318B3F724FE5AFAE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB3F5DC7DE66FB7274E6FB52 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 85E8BD93A66999131D97D401;
+			remoteInfo = "Pods-NYTPhotoViewer-Swift-NYTPhotoViewer";
+		};
+		EEEA7EBB25EF27D55ABA4FD6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB3F5DC7DE66FB7274E6FB52 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2104855B84EF13FE632EC212;
+			remoteInfo = "Pods-NYTPhotoViewer-SwiftTests-OCMock";
+		};
+		F5BB7526AE1EB62A063D4BB7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB3F5DC7DE66FB7274E6FB52 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DACEF04843F4D3AAB41E45B9;
+			remoteInfo = "Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0173576ECF18C2B5B84DA883 /* OCMInvocationExpectation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMInvocationExpectation.m; path = Source/OCMock/OCMInvocationExpectation.m; sourceTree = "<group>"; };
+		024111B35564B48AE0023AA9 /* Pods-Tests-OCMock-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-Tests-OCMock-dummy.m"; path = "../Pods-Tests-OCMock/Pods-Tests-OCMock-dummy.m"; sourceTree = "<group>"; };
+		07BAB14A5F32DDF1574F2E99 /* OCMIndirectReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMIndirectReturnValueProvider.h; path = Source/OCMock/OCMIndirectReturnValueProvider.h; sourceTree = "<group>"; };
+		0AAA1B247A4A215F7A5907E3 /* OCMInvocationMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMInvocationMatcher.m; path = Source/OCMock/OCMInvocationMatcher.m; sourceTree = "<group>"; };
+		11D73809917EC52B050827A3 /* libPods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		130B84B5FC7EDFBA3CF03BD8 /* OCProtocolMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCProtocolMockObject.m; path = Source/OCMock/OCProtocolMockObject.m; sourceTree = "<group>"; };
+		1629E9E9F8042A2096E475B3 /* NYTPhoto.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTPhoto.h; path = Pod/Classes/ios/Protocols/NYTPhoto.h; sourceTree = "<group>"; };
+		16FAD106A2022C3575D8A3AB /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-Private.xcconfig"; path = "../Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-Private.xcconfig"; sourceTree = "<group>"; };
+		1944CBEDD7EB3F42ABB7035D /* OCMLocation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMLocation.h; path = Source/OCMock/OCMLocation.h; sourceTree = "<group>"; };
+		1A2EFE1FDE8C273E41FBFCF5 /* OCMExceptionReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMExceptionReturnValueProvider.m; path = Source/OCMock/OCMExceptionReturnValueProvider.m; sourceTree = "<group>"; };
+		1B46B16FEBC59A4373810420 /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		1C15D35E2817745B63904821 /* OCMExpectationRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMExpectationRecorder.h; path = Source/OCMock/OCMExpectationRecorder.h; sourceTree = "<group>"; };
+		1FE1180B890870E37CBC1D98 /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-dummy.m"; path = "../Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-dummy.m"; sourceTree = "<group>"; };
+		22048393DB660082285AF393 /* Pods-NYTPhotoViewer-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-NYTPhotoViewer-dummy.m"; sourceTree = "<group>"; };
+		2569F5D65FEFD9942A27325B /* OCMInvocationExpectation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMInvocationExpectation.h; path = Source/OCMock/OCMInvocationExpectation.h; sourceTree = "<group>"; };
+		2739CDA5AB001D7AEFEF9734 /* OCMConstraint.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMConstraint.h; path = Source/OCMock/OCMConstraint.h; sourceTree = "<group>"; };
+		2A81BD0B1B56F91100EE971C /* NYTPhotoViewer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NYTPhotoViewer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2A81BD0E1B56F91100EE971C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2A81BD0F1B56F91100EE971C /* NYTPhotoViewer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYTPhotoViewer.h; sourceTree = "<group>"; };
+		2A81BD151B56F91100EE971C /* NYTPhotoViewerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NYTPhotoViewerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2A81BD1B1B56F91100EE971C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2A81BD1C1B56F91100EE971C /* NYTPhotoViewerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYTPhotoViewerTests.m; sourceTree = "<group>"; };
+		2CAB01BCB2E5807A82F681E7 /* Pods-NYTPhotoViewer-SwiftTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-NYTPhotoViewer-SwiftTests-dummy.m"; sourceTree = "<group>"; };
+		2DDA1EE2FA4741E1C1A57FAB /* OCMBoxedReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMBoxedReturnValueProvider.m; path = Source/OCMock/OCMBoxedReturnValueProvider.m; sourceTree = "<group>"; };
+		307DC766F062DA6F22E0A8C2 /* OCMBlockCaller.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMBlockCaller.h; path = Source/OCMock/OCMBlockCaller.h; sourceTree = "<group>"; };
+		33DB338CD9DE1D0398777F16 /* Pods-Tests-NYTPhotoViewer-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-NYTPhotoViewer-Private.xcconfig"; path = "../Pods-Tests-NYTPhotoViewer/Pods-Tests-NYTPhotoViewer-Private.xcconfig"; sourceTree = "<group>"; };
+		33DC27FA73F298AF8E69D7AB /* NYTPhotoCaptionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NYTPhotoCaptionView.m; path = Pod/Classes/ios/NYTPhotoCaptionView.m; sourceTree = "<group>"; };
+		34B5CAE55D0AED1F4718B537 /* NSNotificationCenter+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+OCMAdditions.m"; path = "Source/OCMock/NSNotificationCenter+OCMAdditions.m"; sourceTree = "<group>"; };
+		35DB72DE358DA5D2122E1B97 /* NYTPhotoViewerCloseButtonX@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "NYTPhotoViewerCloseButtonX@3x.png"; path = "Pod/Assets/ios/NYTPhotoViewerCloseButtonX@3x.png"; sourceTree = "<group>"; };
+		3669B7BC097736BFF008062A /* Pods-NYTPhotoViewer-SwiftTests-OCMock-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NYTPhotoViewer-SwiftTests-OCMock-Private.xcconfig"; sourceTree = "<group>"; };
+		3713D32BDA852095EA2A73DE /* OCMStubRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMStubRecorder.h; path = Source/OCMock/OCMStubRecorder.h; sourceTree = "<group>"; };
+		38622758EBC4096408358F2A /* Pods-NYTPhotoViewer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NYTPhotoViewer.release.xcconfig"; sourceTree = "<group>"; };
+		38E5FA1FF570E28DB4310AFF /* OCMock.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMock.h; path = Source/OCMock/OCMock.h; sourceTree = "<group>"; };
+		3B934FCE1F8716091A32FE81 /* libPods-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D37504764B63A760E2F7301 /* NYTPhotoViewerCloseButtonXLandscape@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "NYTPhotoViewerCloseButtonXLandscape@3x.png"; path = "Pod/Assets/ios/NYTPhotoViewerCloseButtonXLandscape@3x.png"; sourceTree = "<group>"; };
+		420283FDC853B11367189E39 /* NYTPhotoViewerCloseButtonXLandscape.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = NYTPhotoViewerCloseButtonXLandscape.png; path = Pod/Assets/ios/NYTPhotoViewerCloseButtonXLandscape.png; sourceTree = "<group>"; };
+		4233DAABFADA2023EB350D79 /* OCMReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMReturnValueProvider.m; path = Source/OCMock/OCMReturnValueProvider.m; sourceTree = "<group>"; };
+		4375A6EB96FD307D003D6671 /* Pods-NYTPhotoViewer-SwiftTests-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-NYTPhotoViewer-SwiftTests-environment.h"; sourceTree = "<group>"; };
+		44800019A7D1F62A409C02AB /* OCMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMockObject.h; path = Source/OCMock/OCMockObject.h; sourceTree = "<group>"; };
+		45FB9190CA97B941207A4630 /* NYTPhotosOverlayView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NYTPhotosOverlayView.m; path = Pod/Classes/ios/NYTPhotosOverlayView.m; sourceTree = "<group>"; };
+		46A58C3669B50A2A63A8C185 /* OCMPassByRefSetter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMPassByRefSetter.m; path = Source/OCMock/OCMPassByRefSetter.m; sourceTree = "<group>"; };
+		49A80A0AD117B07B14D521F5 /* OCMNotificationPoster.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMNotificationPoster.h; path = Source/OCMock/OCMNotificationPoster.h; sourceTree = "<group>"; };
+		49E0C917D1519C6A9446AD9E /* OCMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMockObject.m; path = Source/OCMock/OCMockObject.m; sourceTree = "<group>"; };
+		4AA001EFA3696F3A3ECC1C5A /* OCMArg.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMArg.m; path = Source/OCMock/OCMArg.m; sourceTree = "<group>"; };
+		4D5AFE219FE801BFEBAD7183 /* OCMObserverRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMObserverRecorder.h; path = Source/OCMock/OCMObserverRecorder.h; sourceTree = "<group>"; };
+		4F62A02EEC12B031041E9587 /* Pods-NYTPhotoViewer-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-NYTPhotoViewer-acknowledgements.markdown"; sourceTree = "<group>"; };
+		4F7F25301AED7A40B5D2CF06 /* OCObserverMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCObserverMockObject.m; path = Source/OCMock/OCObserverMockObject.m; sourceTree = "<group>"; };
+		52C049C4964CFC4996FCDFD9 /* Pods-NYTPhotoViewer-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-NYTPhotoViewer-acknowledgements.plist"; sourceTree = "<group>"; };
+		574D9F0AFA4EF8C714F0444E /* ios */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; name = ios; path = Pod/Assets/ios; sourceTree = "<group>"; };
+		5A0B46673310BD28D06AE956 /* libPods-NYTPhotoViewer.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NYTPhotoViewer.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B02D56495BF8A566E8EA6AD /* NSNotificationCenter+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+OCMAdditions.h"; path = "Source/OCMock/NSNotificationCenter+OCMAdditions.h"; sourceTree = "<group>"; };
+		5D8AC5A109BD394BDE891454 /* OCMLocation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMLocation.m; path = Source/OCMock/OCMLocation.m; sourceTree = "<group>"; };
+		5F6CBF3D584CD42B55AEB1DF /* OCMInvocationStub.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMInvocationStub.h; path = Source/OCMock/OCMInvocationStub.h; sourceTree = "<group>"; };
+		5FF2A0F71C89297574749F2C /* NSValue+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+OCMAdditions.h"; path = "Source/OCMock/NSValue+OCMAdditions.h"; sourceTree = "<group>"; };
+		6079A0558D711495BE091573 /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer.xcconfig"; path = "../Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer.xcconfig"; sourceTree = "<group>"; };
+		62158E9CABF1BA176E6D4C59 /* NYTPhotosViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTPhotosViewController.h; path = Pod/Classes/ios/NYTPhotosViewController.h; sourceTree = "<group>"; };
+		6478BC6DA1216C5C7E8AB64D /* Pods-Tests-OCMock.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-OCMock.xcconfig"; path = "../Pods-Tests-OCMock/Pods-Tests-OCMock.xcconfig"; sourceTree = "<group>"; };
+		65CBB3F80E251AEA9104CB71 /* OCMVerifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMVerifier.m; path = Source/OCMock/OCMVerifier.m; sourceTree = "<group>"; };
+		66D75152ED32E28D2FCE0ABE /* Pods-NYTPhotoViewer-Swift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NYTPhotoViewer-Swift.release.xcconfig"; sourceTree = "<group>"; };
+		678241CA8DB67251FEDBBD97 /* Pods-Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-resources.sh"; sourceTree = "<group>"; };
+		684EFA81CC3B62CAF710A4D7 /* OCMRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMRecorder.m; path = Source/OCMock/OCMRecorder.m; sourceTree = "<group>"; };
+		68C7BA95CF440E9D0687A898 /* OCMMacroState.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMMacroState.m; path = Source/OCMock/OCMMacroState.m; sourceTree = "<group>"; };
+		69F0FC0376CE26BC3950F5B0 /* OCMRealObjectForwarder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMRealObjectForwarder.m; path = Source/OCMock/OCMRealObjectForwarder.m; sourceTree = "<group>"; };
+		6A31E6153B31E5AA4B08F6A1 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		6CCF7FB922A90B100BF3A650 /* OCMIndirectReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMIndirectReturnValueProvider.m; path = Source/OCMock/OCMIndirectReturnValueProvider.m; sourceTree = "<group>"; };
+		6DF020583EE6DD060F87A029 /* NSValue+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+OCMAdditions.m"; path = "Source/OCMock/NSValue+OCMAdditions.m"; sourceTree = "<group>"; };
+		6E60F98A792FD711A9EBB79B /* NSInvocation+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+OCMAdditions.h"; path = "Source/OCMock/NSInvocation+OCMAdditions.h"; sourceTree = "<group>"; };
+		6F8A19FB9F12A9464B8E14ED /* OCMFunctions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMFunctions.h; path = Source/OCMock/OCMFunctions.h; sourceTree = "<group>"; };
+		6FF81625A83435CF70264B05 /* NYTPhotoViewerCloseButtonX@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "NYTPhotoViewerCloseButtonX@2x.png"; path = "Pod/Assets/ios/NYTPhotoViewerCloseButtonX@2x.png"; sourceTree = "<group>"; };
+		71BC5A9D64F89FE7331C73A3 /* OCMStubRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMStubRecorder.m; path = Source/OCMock/OCMStubRecorder.m; sourceTree = "<group>"; };
+		743F48CD04F7E076541BFC47 /* OCProtocolMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCProtocolMockObject.h; path = Source/OCMock/OCProtocolMockObject.h; sourceTree = "<group>"; };
+		74FFAEFFFD2054400CC52B43 /* libPods-NYTPhotoViewer-Swift-NYTPhotoViewer.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NYTPhotoViewer-Swift-NYTPhotoViewer.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		751F2F2940E6C6148A62FAC6 /* NSObject+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+OCMAdditions.m"; path = "Source/OCMock/NSObject+OCMAdditions.m"; sourceTree = "<group>"; };
+		75E0863BEC7C298CA54E0C41 /* libPods-Tests-OCMock.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests-OCMock.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7E67C1CC845E11FBFD6A0365 /* Pods-Tests-OCMock-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-Tests-OCMock-prefix.pch"; path = "../Pods-Tests-OCMock/Pods-Tests-OCMock-prefix.pch"; sourceTree = "<group>"; };
+		7ED9B5A247E60C8B705F6C7D /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-prefix.pch"; path = "../Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-prefix.pch"; sourceTree = "<group>"; };
+		7F67EE3634297DF862DA26A1 /* Pods-NYTPhotoViewer-SwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NYTPhotoViewer-SwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
+		806A3C92AC1C8976713B07B4 /* libPods-NYTPhotoViewer-SwiftTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NYTPhotoViewer-SwiftTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		856456FA1A25692FEFC3FE28 /* OCMExceptionReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMExceptionReturnValueProvider.h; path = Source/OCMock/OCMExceptionReturnValueProvider.h; sourceTree = "<group>"; };
+		85B981625089E45E1C42CDE4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		8647301F5C968345D6C65BB3 /* OCMBlockCaller.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMBlockCaller.m; path = Source/OCMock/OCMBlockCaller.m; sourceTree = "<group>"; };
+		86B43563820BACECDECDBA14 /* Pods-NYTPhotoViewer-NYTPhotoViewer-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NYTPhotoViewer-NYTPhotoViewer-Private.xcconfig"; sourceTree = "<group>"; };
+		87264381DE7CA6CDF3B56575 /* OCClassMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCClassMockObject.h; path = Source/OCMock/OCClassMockObject.h; sourceTree = "<group>"; };
+		87EB1BF6CEA3F1873E4FFA50 /* NYTPhotosViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NYTPhotosViewController.m; path = Pod/Classes/ios/NYTPhotosViewController.m; sourceTree = "<group>"; };
+		8A71387381A723E740927E59 /* NSObject+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+OCMAdditions.h"; path = "Source/OCMock/NSObject+OCMAdditions.h"; sourceTree = "<group>"; };
+		8B0ACC9B5708AD621EE5F694 /* libPods-Tests-NYTPhotoViewer.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests-NYTPhotoViewer.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8C98F7877C29008627A2D842 /* NYTPhotoViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NYTPhotoViewController.m; path = Pod/Classes/ios/NYTPhotoViewController.m; sourceTree = "<group>"; };
+		903209471199CAEE3B42CA19 /* NYTPhotoTransitionAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NYTPhotoTransitionAnimator.m; path = Pod/Classes/ios/NYTPhotoTransitionAnimator.m; sourceTree = "<group>"; };
+		9075BF902932F4D3B5717B4E /* NYTPhotoViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTPhotoViewController.h; path = Pod/Classes/ios/NYTPhotoViewController.h; sourceTree = "<group>"; };
+		909E4A4842ED3B4B3B96CB32 /* NYTPhotoViewerCloseButtonX.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = NYTPhotoViewerCloseButtonX.png; path = Pod/Assets/ios/NYTPhotoViewerCloseButtonX.png; sourceTree = "<group>"; };
+		918AC8496C7782C8A3A27FD8 /* OCMArg.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMArg.h; path = Source/OCMock/OCMArg.h; sourceTree = "<group>"; };
+		959C8D3D088313E20DA6AB65 /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-dummy.m"; path = "../Pods-NYTPhotoViewer-Swift-NYTPhotoViewer/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-dummy.m"; sourceTree = "<group>"; };
+		9780D65FCFCBFB28EAB66199 /* libPods-NYTPhotoViewer-NYTPhotoViewer.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NYTPhotoViewer-NYTPhotoViewer.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9846BBCE91D248C6CBDC83C1 /* OCMFunctions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMFunctions.m; path = Source/OCMock/OCMFunctions.m; sourceTree = "<group>"; };
+		9B040E70EDBEAEADF8496E0E /* Pods-Tests-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Tests-environment.h"; sourceTree = "<group>"; };
+		9B2915B5408DB212F1A872B0 /* NYTPhotoDismissalInteractionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTPhotoDismissalInteractionController.h; path = Pod/Classes/ios/NYTPhotoDismissalInteractionController.h; sourceTree = "<group>"; };
+		9C786A328D2718F86DBDCFEB /* Pods-Tests-NYTPhotoViewer-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-Tests-NYTPhotoViewer-prefix.pch"; path = "../Pods-Tests-NYTPhotoViewer/Pods-Tests-NYTPhotoViewer-prefix.pch"; sourceTree = "<group>"; };
+		9D87D675530D9E1778566F6E /* Pods-NYTPhotoViewer-SwiftTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-NYTPhotoViewer-SwiftTests-acknowledgements.plist"; sourceTree = "<group>"; };
+		9DB501DA0B2A3723253C024C /* OCMInvocationMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMInvocationMatcher.h; path = Source/OCMock/OCMInvocationMatcher.h; sourceTree = "<group>"; };
+		9DD26D85E326E913CEE025D8 /* NYTScalingImageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTScalingImageView.h; path = Pod/Classes/ios/NYTScalingImageView.h; sourceTree = "<group>"; };
+		9F3A7D773EBE5202342C4AA7 /* Pods-NYTPhotoViewer-Swift-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-NYTPhotoViewer-Swift-acknowledgements.plist"; sourceTree = "<group>"; };
+		9F58613E0A68B64D461E3280 /* NYTOperatingSystemCompatibilityUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NYTOperatingSystemCompatibilityUtility.m; path = Pod/Classes/ios/NYTOperatingSystemCompatibilityUtility.m; sourceTree = "<group>"; };
+		9FB3EC2C4D5F6F924DF2EBBA /* OCMPassByRefSetter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMPassByRefSetter.h; path = Source/OCMock/OCMPassByRefSetter.h; sourceTree = "<group>"; };
+		A2AA39193DA6E68F7B97B3A0 /* NYTPhotosViewControllerDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTPhotosViewControllerDataSource.h; path = Pod/Classes/ios/Protocols/NYTPhotosViewControllerDataSource.h; sourceTree = "<group>"; };
+		A7885EBD8438F61F0BBF5DEE /* OCPartialMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCPartialMockObject.h; path = Source/OCMock/OCPartialMockObject.h; sourceTree = "<group>"; };
+		AAA8E9CA90F9F4E53479B764 /* Pods-Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		AC9878B540D77AA436459189 /* NYTPhotoTransitionAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTPhotoTransitionAnimator.h; path = Pod/Classes/ios/NYTPhotoTransitionAnimator.h; sourceTree = "<group>"; };
+		ACE8A9A636D7CE6B4411216A /* OCMConstraint.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMConstraint.m; path = Source/OCMock/OCMConstraint.m; sourceTree = "<group>"; };
+		AF43AB7738928F01FCFDF183 /* Pods-NYTPhotoViewer-Swift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NYTPhotoViewer-Swift.debug.xcconfig"; sourceTree = "<group>"; };
+		B0144A696A1552A965AE5DA3 /* Pods-NYTPhotoViewer-SwiftTests-OCMock-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-NYTPhotoViewer-SwiftTests-OCMock-prefix.pch"; sourceTree = "<group>"; };
+		B0222A66BB9F7F439575B8F0 /* OCMMacroState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMMacroState.h; path = Source/OCMock/OCMMacroState.h; sourceTree = "<group>"; };
+		B12F9AC1F97C4FE18FA0DD03 /* Pods-NYTPhotoViewer-NYTPhotoViewer-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-NYTPhotoViewer-NYTPhotoViewer-dummy.m"; sourceTree = "<group>"; };
+		B25294FB0CF98C5B8D595A88 /* Pods-NYTPhotoViewer-SwiftTests-OCMock.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NYTPhotoViewer-SwiftTests-OCMock.xcconfig"; sourceTree = "<group>"; };
+		B2926136463FFA4168502AA1 /* OCPartialMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCPartialMockObject.m; path = Source/OCMock/OCPartialMockObject.m; sourceTree = "<group>"; };
+		B3B96ABE1A56CDFBB87DED83 /* NYTPhotoViewerCloseButtonXLandscape@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "NYTPhotoViewerCloseButtonXLandscape@2x.png"; path = "Pod/Assets/ios/NYTPhotoViewerCloseButtonXLandscape@2x.png"; sourceTree = "<group>"; };
+		B720DA40341976378A8B14AE /* Pods-Tests-NYTPhotoViewer.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-NYTPhotoViewer.xcconfig"; path = "../Pods-Tests-NYTPhotoViewer/Pods-Tests-NYTPhotoViewer.xcconfig"; sourceTree = "<group>"; };
+		B8D7B9932B3747FDA8D1A6FF /* OCMNotificationPoster.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMNotificationPoster.m; path = Source/OCMock/OCMNotificationPoster.m; sourceTree = "<group>"; };
+		B9164895990534371A09C187 /* NYTScalingImageView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NYTScalingImageView.m; path = Pod/Classes/ios/NYTScalingImageView.m; sourceTree = "<group>"; };
+		B9259EA232551DA556BEF6BC /* OCMInvocationStub.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMInvocationStub.m; path = Source/OCMock/OCMInvocationStub.m; sourceTree = "<group>"; };
+		B9D0611732608546131C68AB /* NYTPhotoTransitionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTPhotoTransitionController.h; path = Pod/Classes/ios/NYTPhotoTransitionController.h; sourceTree = "<group>"; };
+		BEF933B04E5D228A7A18ADDA /* NYTPhotoCaptionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTPhotoCaptionView.h; path = Pod/Classes/ios/NYTPhotoCaptionView.h; sourceTree = "<group>"; };
+		BF0D05246C62850F5776E5C1 /* Pods-NYTPhotoViewer-NYTPhotoViewer-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-NYTPhotoViewer-NYTPhotoViewer-prefix.pch"; sourceTree = "<group>"; };
+		C28EC605D89C35382082A6E2 /* Pods-NYTPhotoViewer-Swift-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-NYTPhotoViewer-Swift-acknowledgements.markdown"; sourceTree = "<group>"; };
+		C3238309106D63A91FE528C9 /* OCMRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMRecorder.h; path = Source/OCMock/OCMRecorder.h; sourceTree = "<group>"; };
+		C34EE63F2441725BAE7C1B69 /* NSMethodSignature+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSMethodSignature+OCMAdditions.h"; path = "Source/OCMock/NSMethodSignature+OCMAdditions.h"; sourceTree = "<group>"; };
+		C381950D67F1AE46264A6AF8 /* Pods-Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tests-dummy.m"; sourceTree = "<group>"; };
+		C9BB0C33DC6D2674A2650FDA /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-Private.xcconfig"; path = "../Pods-NYTPhotoViewer-Swift-NYTPhotoViewer/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-Private.xcconfig"; sourceTree = "<group>"; };
+		CA18D29B4A53538648260D21 /* OCMVerifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMVerifier.h; path = Source/OCMock/OCMVerifier.h; sourceTree = "<group>"; };
+		CABBA1BAA3054F876B0C8F01 /* OCMObserverRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMObserverRecorder.m; path = Source/OCMock/OCMObserverRecorder.m; sourceTree = "<group>"; };
+		CB9CD201886329065C717498 /* Pods-NYTPhotoViewer-SwiftTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-NYTPhotoViewer-SwiftTests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		CD9947A04D9C9E1BE5FF0B1D /* Pods-NYTPhotoViewer-Swift-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-NYTPhotoViewer-Swift-resources.sh"; sourceTree = "<group>"; };
+		CF7C82773CF45E8ABC34D9BC /* libPods-NYTPhotoViewer-SwiftTests-OCMock.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NYTPhotoViewer-SwiftTests-OCMock.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D111BD4C163B390AEAF136CB /* Pods-Tests-OCMock-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-OCMock-Private.xcconfig"; path = "../Pods-Tests-OCMock/Pods-Tests-OCMock-Private.xcconfig"; sourceTree = "<group>"; };
+		D3585DE44F744998B63E2F8E /* Pods-NYTPhotoViewer-SwiftTests-OCMock-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-NYTPhotoViewer-SwiftTests-OCMock-dummy.m"; sourceTree = "<group>"; };
+		D68D0582B96DB4EDB28B7091 /* libPods-NYTPhotoViewer-Swift.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NYTPhotoViewer-Swift.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D714BC42AFE98071E83FB55A /* NYTPhotosDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NYTPhotosDataSource.m; path = Pod/Classes/ios/NYTPhotosDataSource.m; sourceTree = "<group>"; };
+		DCE4C4A3CC66AFA2646C365C /* NYTPhotosOverlayView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTPhotosOverlayView.h; path = Pod/Classes/ios/NYTPhotosOverlayView.h; sourceTree = "<group>"; };
+		DE9BD92CACFDFD7DE3D8533B /* NSInvocation+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+OCMAdditions.m"; path = "Source/OCMock/NSInvocation+OCMAdditions.m"; sourceTree = "<group>"; };
+		DF8B2633864CE2EE3E36A1EA /* Pods-NYTPhotoViewer-SwiftTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-NYTPhotoViewer-SwiftTests-resources.sh"; sourceTree = "<group>"; };
+		E031EE8F4B8D8A72CCBB2B85 /* OCClassMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCClassMockObject.m; path = Source/OCMock/OCClassMockObject.m; sourceTree = "<group>"; };
+		E096CC3BD1B1819E9AC7C755 /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-prefix.pch"; path = "../Pods-NYTPhotoViewer-Swift-NYTPhotoViewer/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-prefix.pch"; sourceTree = "<group>"; };
+		E0A98A7C6AB18D4103E0D87A /* NYTPhotoDismissalInteractionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NYTPhotoDismissalInteractionController.m; path = Pod/Classes/ios/NYTPhotoDismissalInteractionController.m; sourceTree = "<group>"; };
+		E10ACCFC67198E49FA479F63 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		E1FCC4F652AA3FDA50D64379 /* Pods-NYTPhotoViewer-NYTPhotoViewer.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NYTPhotoViewer-NYTPhotoViewer.xcconfig"; sourceTree = "<group>"; };
+		E26846BA9A7F6C234C6AFD85 /* NSMethodSignature+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSMethodSignature+OCMAdditions.m"; path = "Source/OCMock/NSMethodSignature+OCMAdditions.m"; sourceTree = "<group>"; };
+		E2D401B06064CBCBE38FFEF4 /* NYTPhotoTransitionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NYTPhotoTransitionController.m; path = Pod/Classes/ios/NYTPhotoTransitionController.m; sourceTree = "<group>"; };
+		E2E4B5C18DCD84D83B675BEF /* Pods-NYTPhotoViewer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NYTPhotoViewer.debug.xcconfig"; sourceTree = "<group>"; };
+		E6DAE5C9B678B75FB1C80454 /* Pods-NYTPhotoViewer-Swift-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-NYTPhotoViewer-Swift-environment.h"; sourceTree = "<group>"; };
+		E9ACDC7D73AD65931322460C /* OCObserverMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCObserverMockObject.h; path = Source/OCMock/OCObserverMockObject.h; sourceTree = "<group>"; };
+		EB760647CD2C6D6AF095ECD2 /* NYTOperatingSystemCompatibilityUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTOperatingSystemCompatibilityUtility.h; path = Pod/Classes/ios/NYTOperatingSystemCompatibilityUtility.h; sourceTree = "<group>"; };
+		EC61D2C6034C7A5815BE03F3 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		EFA58414A5B2F1CBFC1BECAC /* NYTPhotoContainer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTPhotoContainer.h; path = Pod/Classes/ios/Protocols/NYTPhotoContainer.h; sourceTree = "<group>"; };
+		F13CABD95AF1FEB2271C600E /* Pods-Tests-NYTPhotoViewer-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-Tests-NYTPhotoViewer-dummy.m"; path = "../Pods-Tests-NYTPhotoViewer/Pods-Tests-NYTPhotoViewer-dummy.m"; sourceTree = "<group>"; };
+		F1BCFEA54E76501FBCB5E4C4 /* OCMExpectationRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMExpectationRecorder.m; path = Source/OCMock/OCMExpectationRecorder.m; sourceTree = "<group>"; };
+		F262EA2711B86BFF08D5DA96 /* OCMBoxedReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMBoxedReturnValueProvider.h; path = Source/OCMock/OCMBoxedReturnValueProvider.h; sourceTree = "<group>"; };
+		F2BE408A7422AFE4DE7B67E2 /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NYTPhotoViewer-Swift-NYTPhotoViewer.xcconfig"; path = "../Pods-NYTPhotoViewer-Swift-NYTPhotoViewer/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer.xcconfig"; sourceTree = "<group>"; };
+		F4419E858FEA7948D6AE7CFF /* Pods-NYTPhotoViewer-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-NYTPhotoViewer-environment.h"; sourceTree = "<group>"; };
+		F4E78FC4A2B44F075EAE31FA /* Pods-NYTPhotoViewer-Swift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-NYTPhotoViewer-Swift-dummy.m"; sourceTree = "<group>"; };
+		F6E67ADB8E8582FDA08A8CBC /* Pods-NYTPhotoViewer-SwiftTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NYTPhotoViewer-SwiftTests.release.xcconfig"; sourceTree = "<group>"; };
+		F8846770DB6FA58A8155EE1B /* Pods-Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		FA3488EC2BDD028C8EB901C0 /* OCMReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMReturnValueProvider.h; path = Source/OCMock/OCMReturnValueProvider.h; sourceTree = "<group>"; };
+		FC05C962D1CFA81F0AD78A33 /* OCMRealObjectForwarder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMRealObjectForwarder.h; path = Source/OCMock/OCMRealObjectForwarder.h; sourceTree = "<group>"; };
+		FDDAB3E5CB605CC4BA09C1AF /* Pods-NYTPhotoViewer-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-NYTPhotoViewer-resources.sh"; sourceTree = "<group>"; };
+		FE7D9F49EDE8F22171327D20 /* NYTPhotosDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NYTPhotosDataSource.h; path = Pod/Classes/ios/NYTPhotosDataSource.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0B7EC604A48FA1C304C0F7CC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F39AA576F184D8F21C72C46A /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		161E063BBEF3983A7CCF5C34 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6D9AEF14DBBDA0549E60E96B /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1DA147F57555614CEA3BA0A2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C921BC00C737DACBEE8A1920 /* Foundation.framework in Frameworks */,
+				E39A56283839D595EFECFD90 /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2666B9448C8F921C33BDE958 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				438A1D6371FE2E2DFF76093A /* Foundation.framework in Frameworks */,
+				C4DD9FFBE917BC0D311424FB /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2A81BD071B56F91100EE971C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2A81BD121B56F91100EE971C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2A81BD161B56F91100EE971C /* NYTPhotoViewer.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4F8314F6055C7954A72B9B51 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A1BC8AF7009E227336CD76E /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		68369090B42B85AEAB024660 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				874CCF36599385E29622AC1E /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7EC47F014DF1D58DA8A1DE1E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7F1B41130A03CDC9789CDEDE /* Foundation.framework in Frameworks */,
+				E3FF72A44A06BE2DE21C2270 /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		95E635757BB30FAC83F6C156 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E734218E81D4249D07D22ADC /* Foundation.framework in Frameworks */,
+				878568BFE16D81A4A00DD87A /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E0F9E06D4BD660FA010FF66E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2176793C28BC562FDAE85D3F /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F28E2AFACDB161074E8DEEE3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				19E8A25A23F1C3B97D1B7CD2 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		11852500FC148A8C2C2CCBD8 /* Pods-NYTPhotoViewer-SwiftTests */ = {
+			isa = PBXGroup;
+			children = (
+				CB9CD201886329065C717498 /* Pods-NYTPhotoViewer-SwiftTests-acknowledgements.markdown */,
+				9D87D675530D9E1778566F6E /* Pods-NYTPhotoViewer-SwiftTests-acknowledgements.plist */,
+				2CAB01BCB2E5807A82F681E7 /* Pods-NYTPhotoViewer-SwiftTests-dummy.m */,
+				4375A6EB96FD307D003D6671 /* Pods-NYTPhotoViewer-SwiftTests-environment.h */,
+				DF8B2633864CE2EE3E36A1EA /* Pods-NYTPhotoViewer-SwiftTests-resources.sh */,
+				7F67EE3634297DF862DA26A1 /* Pods-NYTPhotoViewer-SwiftTests.debug.xcconfig */,
+				F6E67ADB8E8582FDA08A8CBC /* Pods-NYTPhotoViewer-SwiftTests.release.xcconfig */,
+			);
+			name = "Pods-NYTPhotoViewer-SwiftTests";
+			path = "Target Support Files/Pods-NYTPhotoViewer-SwiftTests";
+			sourceTree = "<group>";
+		};
+		1E38B48D281A26A00772C5A7 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				909E4A4842ED3B4B3B96CB32 /* NYTPhotoViewerCloseButtonX.png */,
+				6FF81625A83435CF70264B05 /* NYTPhotoViewerCloseButtonX@2x.png */,
+				35DB72DE358DA5D2122E1B97 /* NYTPhotoViewerCloseButtonX@3x.png */,
+				420283FDC853B11367189E39 /* NYTPhotoViewerCloseButtonXLandscape.png */,
+				B3B96ABE1A56CDFBB87DED83 /* NYTPhotoViewerCloseButtonXLandscape@2x.png */,
+				3D37504764B63A760E2F7301 /* NYTPhotoViewerCloseButtonXLandscape@3x.png */,
+				574D9F0AFA4EF8C714F0444E /* ios */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		2A81BD0C1B56F91100EE971C /* NYTPhotoViewer */ = {
+			isa = PBXGroup;
+			children = (
+				2A81BD0F1B56F91100EE971C /* NYTPhotoViewer.h */,
+				2A81BD0D1B56F91100EE971C /* Supporting Files */,
+			);
+			path = NYTPhotoViewer;
+			sourceTree = "<group>";
+		};
+		2A81BD0D1B56F91100EE971C /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				2A81BD0E1B56F91100EE971C /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		2A81BD191B56F91100EE971C /* NYTPhotoViewerTests */ = {
+			isa = PBXGroup;
+			children = (
+				2A81BD1C1B56F91100EE971C /* NYTPhotoViewerTests.m */,
+				2A81BD1A1B56F91100EE971C /* Supporting Files */,
+			);
+			path = NYTPhotoViewerTests;
+			sourceTree = "<group>";
+		};
+		2A81BD1A1B56F91100EE971C /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				2A81BD1B1B56F91100EE971C /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		2DE06652D777E39D9A720FDD /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				B25294FB0CF98C5B8D595A88 /* Pods-NYTPhotoViewer-SwiftTests-OCMock.xcconfig */,
+				3669B7BC097736BFF008062A /* Pods-NYTPhotoViewer-SwiftTests-OCMock-Private.xcconfig */,
+				D3585DE44F744998B63E2F8E /* Pods-NYTPhotoViewer-SwiftTests-OCMock-dummy.m */,
+				B0144A696A1552A965AE5DA3 /* Pods-NYTPhotoViewer-SwiftTests-OCMock-prefix.pch */,
+				6478BC6DA1216C5C7E8AB64D /* Pods-Tests-OCMock.xcconfig */,
+				D111BD4C163B390AEAF136CB /* Pods-Tests-OCMock-Private.xcconfig */,
+				024111B35564B48AE0023AA9 /* Pods-Tests-OCMock-dummy.m */,
+				7E67C1CC845E11FBFD6A0365 /* Pods-Tests-OCMock-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-NYTPhotoViewer-SwiftTests-OCMock";
+			sourceTree = "<group>";
+		};
+		300D825A591949CAB22D43DF = {
+			isa = PBXGroup;
+			children = (
+				1B46B16FEBC59A4373810420 /* Podfile */,
+				7378F61C8B0BBFBE180039FB /* Development Pods */,
+				2A81BD0C1B56F91100EE971C /* NYTPhotoViewer */,
+				2A81BD191B56F91100EE971C /* NYTPhotoViewerTests */,
+				F9D571D2B40CA5A4BF7C7E69 /* Frameworks */,
+				D2C3D477134FE14E09FC534B /* Pods */,
+				7C0F5C2FCCF6271836A3C232 /* Products */,
+				69FDB42127BB90AD54DC6372 /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		37D61A65EE3B2675B96E4513 /* Pods-NYTPhotoViewer */ = {
+			isa = PBXGroup;
+			children = (
+				4F62A02EEC12B031041E9587 /* Pods-NYTPhotoViewer-acknowledgements.markdown */,
+				52C049C4964CFC4996FCDFD9 /* Pods-NYTPhotoViewer-acknowledgements.plist */,
+				22048393DB660082285AF393 /* Pods-NYTPhotoViewer-dummy.m */,
+				F4419E858FEA7948D6AE7CFF /* Pods-NYTPhotoViewer-environment.h */,
+				FDDAB3E5CB605CC4BA09C1AF /* Pods-NYTPhotoViewer-resources.sh */,
+				E2E4B5C18DCD84D83B675BEF /* Pods-NYTPhotoViewer.debug.xcconfig */,
+				38622758EBC4096408358F2A /* Pods-NYTPhotoViewer.release.xcconfig */,
+			);
+			name = "Pods-NYTPhotoViewer";
+			path = "Target Support Files/Pods-NYTPhotoViewer";
+			sourceTree = "<group>";
+		};
+		47299642D8B9EE530BB811E3 /* NYTPhotoViewer */ = {
+			isa = PBXGroup;
+			children = (
+				EB760647CD2C6D6AF095ECD2 /* NYTOperatingSystemCompatibilityUtility.h */,
+				9F58613E0A68B64D461E3280 /* NYTOperatingSystemCompatibilityUtility.m */,
+				1629E9E9F8042A2096E475B3 /* NYTPhoto.h */,
+				BEF933B04E5D228A7A18ADDA /* NYTPhotoCaptionView.h */,
+				33DC27FA73F298AF8E69D7AB /* NYTPhotoCaptionView.m */,
+				EFA58414A5B2F1CBFC1BECAC /* NYTPhotoContainer.h */,
+				9B2915B5408DB212F1A872B0 /* NYTPhotoDismissalInteractionController.h */,
+				E0A98A7C6AB18D4103E0D87A /* NYTPhotoDismissalInteractionController.m */,
+				AC9878B540D77AA436459189 /* NYTPhotoTransitionAnimator.h */,
+				903209471199CAEE3B42CA19 /* NYTPhotoTransitionAnimator.m */,
+				B9D0611732608546131C68AB /* NYTPhotoTransitionController.h */,
+				E2D401B06064CBCBE38FFEF4 /* NYTPhotoTransitionController.m */,
+				9075BF902932F4D3B5717B4E /* NYTPhotoViewController.h */,
+				8C98F7877C29008627A2D842 /* NYTPhotoViewController.m */,
+				FE7D9F49EDE8F22171327D20 /* NYTPhotosDataSource.h */,
+				D714BC42AFE98071E83FB55A /* NYTPhotosDataSource.m */,
+				DCE4C4A3CC66AFA2646C365C /* NYTPhotosOverlayView.h */,
+				45FB9190CA97B941207A4630 /* NYTPhotosOverlayView.m */,
+				62158E9CABF1BA176E6D4C59 /* NYTPhotosViewController.h */,
+				87EB1BF6CEA3F1873E4FFA50 /* NYTPhotosViewController.m */,
+				A2AA39193DA6E68F7B97B3A0 /* NYTPhotosViewControllerDataSource.h */,
+				9DD26D85E326E913CEE025D8 /* NYTScalingImageView.h */,
+				B9164895990534371A09C187 /* NYTScalingImageView.m */,
+				1E38B48D281A26A00772C5A7 /* Resources */,
+				D5E7591FF624CA6AB3C1952D /* Support Files */,
+			);
+			name = NYTPhotoViewer;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		6492E956F099D5E6817648BA /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				85B981625089E45E1C42CDE4 /* Foundation.framework */,
+				EC61D2C6034C7A5815BE03F3 /* UIKit.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		69FDB42127BB90AD54DC6372 /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				37D61A65EE3B2675B96E4513 /* Pods-NYTPhotoViewer */,
+				725008D6B50E0F9648C74393 /* Pods-NYTPhotoViewer-Swift */,
+				11852500FC148A8C2C2CCBD8 /* Pods-NYTPhotoViewer-SwiftTests */,
+				AB7980B4555D832C08D56F85 /* Pods-Tests */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		725008D6B50E0F9648C74393 /* Pods-NYTPhotoViewer-Swift */ = {
+			isa = PBXGroup;
+			children = (
+				C28EC605D89C35382082A6E2 /* Pods-NYTPhotoViewer-Swift-acknowledgements.markdown */,
+				9F3A7D773EBE5202342C4AA7 /* Pods-NYTPhotoViewer-Swift-acknowledgements.plist */,
+				F4E78FC4A2B44F075EAE31FA /* Pods-NYTPhotoViewer-Swift-dummy.m */,
+				E6DAE5C9B678B75FB1C80454 /* Pods-NYTPhotoViewer-Swift-environment.h */,
+				CD9947A04D9C9E1BE5FF0B1D /* Pods-NYTPhotoViewer-Swift-resources.sh */,
+				AF43AB7738928F01FCFDF183 /* Pods-NYTPhotoViewer-Swift.debug.xcconfig */,
+				66D75152ED32E28D2FCE0ABE /* Pods-NYTPhotoViewer-Swift.release.xcconfig */,
+			);
+			name = "Pods-NYTPhotoViewer-Swift";
+			path = "Target Support Files/Pods-NYTPhotoViewer-Swift";
+			sourceTree = "<group>";
+		};
+		7378F61C8B0BBFBE180039FB /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				47299642D8B9EE530BB811E3 /* NYTPhotoViewer */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		7C0F5C2FCCF6271836A3C232 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5A0B46673310BD28D06AE956 /* libPods-NYTPhotoViewer.a */,
+				9780D65FCFCBFB28EAB66199 /* libPods-NYTPhotoViewer-NYTPhotoViewer.a */,
+				D68D0582B96DB4EDB28B7091 /* libPods-NYTPhotoViewer-Swift.a */,
+				74FFAEFFFD2054400CC52B43 /* libPods-NYTPhotoViewer-Swift-NYTPhotoViewer.a */,
+				806A3C92AC1C8976713B07B4 /* libPods-NYTPhotoViewer-SwiftTests.a */,
+				11D73809917EC52B050827A3 /* libPods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer.a */,
+				CF7C82773CF45E8ABC34D9BC /* libPods-NYTPhotoViewer-SwiftTests-OCMock.a */,
+				3B934FCE1F8716091A32FE81 /* libPods-Tests.a */,
+				8B0ACC9B5708AD621EE5F694 /* libPods-Tests-NYTPhotoViewer.a */,
+				75E0863BEC7C298CA54E0C41 /* libPods-Tests-OCMock.a */,
+				2A81BD0B1B56F91100EE971C /* NYTPhotoViewer.framework */,
+				2A81BD151B56F91100EE971C /* NYTPhotoViewerTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A8C1DC03AB82353078AB0FB1 /* OCMock */ = {
+			isa = PBXGroup;
+			children = (
+				6E60F98A792FD711A9EBB79B /* NSInvocation+OCMAdditions.h */,
+				DE9BD92CACFDFD7DE3D8533B /* NSInvocation+OCMAdditions.m */,
+				C34EE63F2441725BAE7C1B69 /* NSMethodSignature+OCMAdditions.h */,
+				E26846BA9A7F6C234C6AFD85 /* NSMethodSignature+OCMAdditions.m */,
+				5B02D56495BF8A566E8EA6AD /* NSNotificationCenter+OCMAdditions.h */,
+				34B5CAE55D0AED1F4718B537 /* NSNotificationCenter+OCMAdditions.m */,
+				8A71387381A723E740927E59 /* NSObject+OCMAdditions.h */,
+				751F2F2940E6C6148A62FAC6 /* NSObject+OCMAdditions.m */,
+				5FF2A0F71C89297574749F2C /* NSValue+OCMAdditions.h */,
+				6DF020583EE6DD060F87A029 /* NSValue+OCMAdditions.m */,
+				87264381DE7CA6CDF3B56575 /* OCClassMockObject.h */,
+				E031EE8F4B8D8A72CCBB2B85 /* OCClassMockObject.m */,
+				918AC8496C7782C8A3A27FD8 /* OCMArg.h */,
+				4AA001EFA3696F3A3ECC1C5A /* OCMArg.m */,
+				307DC766F062DA6F22E0A8C2 /* OCMBlockCaller.h */,
+				8647301F5C968345D6C65BB3 /* OCMBlockCaller.m */,
+				F262EA2711B86BFF08D5DA96 /* OCMBoxedReturnValueProvider.h */,
+				2DDA1EE2FA4741E1C1A57FAB /* OCMBoxedReturnValueProvider.m */,
+				2739CDA5AB001D7AEFEF9734 /* OCMConstraint.h */,
+				ACE8A9A636D7CE6B4411216A /* OCMConstraint.m */,
+				856456FA1A25692FEFC3FE28 /* OCMExceptionReturnValueProvider.h */,
+				1A2EFE1FDE8C273E41FBFCF5 /* OCMExceptionReturnValueProvider.m */,
+				1C15D35E2817745B63904821 /* OCMExpectationRecorder.h */,
+				F1BCFEA54E76501FBCB5E4C4 /* OCMExpectationRecorder.m */,
+				6F8A19FB9F12A9464B8E14ED /* OCMFunctions.h */,
+				9846BBCE91D248C6CBDC83C1 /* OCMFunctions.m */,
+				07BAB14A5F32DDF1574F2E99 /* OCMIndirectReturnValueProvider.h */,
+				6CCF7FB922A90B100BF3A650 /* OCMIndirectReturnValueProvider.m */,
+				2569F5D65FEFD9942A27325B /* OCMInvocationExpectation.h */,
+				0173576ECF18C2B5B84DA883 /* OCMInvocationExpectation.m */,
+				9DB501DA0B2A3723253C024C /* OCMInvocationMatcher.h */,
+				0AAA1B247A4A215F7A5907E3 /* OCMInvocationMatcher.m */,
+				5F6CBF3D584CD42B55AEB1DF /* OCMInvocationStub.h */,
+				B9259EA232551DA556BEF6BC /* OCMInvocationStub.m */,
+				1944CBEDD7EB3F42ABB7035D /* OCMLocation.h */,
+				5D8AC5A109BD394BDE891454 /* OCMLocation.m */,
+				B0222A66BB9F7F439575B8F0 /* OCMMacroState.h */,
+				68C7BA95CF440E9D0687A898 /* OCMMacroState.m */,
+				49A80A0AD117B07B14D521F5 /* OCMNotificationPoster.h */,
+				B8D7B9932B3747FDA8D1A6FF /* OCMNotificationPoster.m */,
+				4D5AFE219FE801BFEBAD7183 /* OCMObserverRecorder.h */,
+				CABBA1BAA3054F876B0C8F01 /* OCMObserverRecorder.m */,
+				9FB3EC2C4D5F6F924DF2EBBA /* OCMPassByRefSetter.h */,
+				46A58C3669B50A2A63A8C185 /* OCMPassByRefSetter.m */,
+				FC05C962D1CFA81F0AD78A33 /* OCMRealObjectForwarder.h */,
+				69F0FC0376CE26BC3950F5B0 /* OCMRealObjectForwarder.m */,
+				C3238309106D63A91FE528C9 /* OCMRecorder.h */,
+				684EFA81CC3B62CAF710A4D7 /* OCMRecorder.m */,
+				FA3488EC2BDD028C8EB901C0 /* OCMReturnValueProvider.h */,
+				4233DAABFADA2023EB350D79 /* OCMReturnValueProvider.m */,
+				3713D32BDA852095EA2A73DE /* OCMStubRecorder.h */,
+				71BC5A9D64F89FE7331C73A3 /* OCMStubRecorder.m */,
+				CA18D29B4A53538648260D21 /* OCMVerifier.h */,
+				65CBB3F80E251AEA9104CB71 /* OCMVerifier.m */,
+				38E5FA1FF570E28DB4310AFF /* OCMock.h */,
+				44800019A7D1F62A409C02AB /* OCMockObject.h */,
+				49E0C917D1519C6A9446AD9E /* OCMockObject.m */,
+				E9ACDC7D73AD65931322460C /* OCObserverMockObject.h */,
+				4F7F25301AED7A40B5D2CF06 /* OCObserverMockObject.m */,
+				A7885EBD8438F61F0BBF5DEE /* OCPartialMockObject.h */,
+				B2926136463FFA4168502AA1 /* OCPartialMockObject.m */,
+				743F48CD04F7E076541BFC47 /* OCProtocolMockObject.h */,
+				130B84B5FC7EDFBA3CF03BD8 /* OCProtocolMockObject.m */,
+				2DE06652D777E39D9A720FDD /* Support Files */,
+			);
+			path = OCMock;
+			sourceTree = "<group>";
+		};
+		AB7980B4555D832C08D56F85 /* Pods-Tests */ = {
+			isa = PBXGroup;
+			children = (
+				AAA8E9CA90F9F4E53479B764 /* Pods-Tests-acknowledgements.markdown */,
+				F8846770DB6FA58A8155EE1B /* Pods-Tests-acknowledgements.plist */,
+				C381950D67F1AE46264A6AF8 /* Pods-Tests-dummy.m */,
+				9B040E70EDBEAEADF8496E0E /* Pods-Tests-environment.h */,
+				678241CA8DB67251FEDBBD97 /* Pods-Tests-resources.sh */,
+				E10ACCFC67198E49FA479F63 /* Pods-Tests.debug.xcconfig */,
+				6A31E6153B31E5AA4B08F6A1 /* Pods-Tests.release.xcconfig */,
+			);
+			name = "Pods-Tests";
+			path = "Target Support Files/Pods-Tests";
+			sourceTree = "<group>";
+		};
+		D2C3D477134FE14E09FC534B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				A8C1DC03AB82353078AB0FB1 /* OCMock */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		D5E7591FF624CA6AB3C1952D /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				E1FCC4F652AA3FDA50D64379 /* Pods-NYTPhotoViewer-NYTPhotoViewer.xcconfig */,
+				86B43563820BACECDECDBA14 /* Pods-NYTPhotoViewer-NYTPhotoViewer-Private.xcconfig */,
+				B12F9AC1F97C4FE18FA0DD03 /* Pods-NYTPhotoViewer-NYTPhotoViewer-dummy.m */,
+				BF0D05246C62850F5776E5C1 /* Pods-NYTPhotoViewer-NYTPhotoViewer-prefix.pch */,
+				F2BE408A7422AFE4DE7B67E2 /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer.xcconfig */,
+				C9BB0C33DC6D2674A2650FDA /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-Private.xcconfig */,
+				959C8D3D088313E20DA6AB65 /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-dummy.m */,
+				E096CC3BD1B1819E9AC7C755 /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-prefix.pch */,
+				6079A0558D711495BE091573 /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer.xcconfig */,
+				16FAD106A2022C3575D8A3AB /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-Private.xcconfig */,
+				1FE1180B890870E37CBC1D98 /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-dummy.m */,
+				7ED9B5A247E60C8B705F6C7D /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-prefix.pch */,
+				B720DA40341976378A8B14AE /* Pods-Tests-NYTPhotoViewer.xcconfig */,
+				33DB338CD9DE1D0398777F16 /* Pods-Tests-NYTPhotoViewer-Private.xcconfig */,
+				F13CABD95AF1FEB2271C600E /* Pods-Tests-NYTPhotoViewer-dummy.m */,
+				9C786A328D2718F86DBDCFEB /* Pods-Tests-NYTPhotoViewer-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/Pods-NYTPhotoViewer-NYTPhotoViewer";
+			sourceTree = "<group>";
+		};
+		F9D571D2B40CA5A4BF7C7E69 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				6492E956F099D5E6817648BA /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		1334361CABA6075E465C7832 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				623099A9AF2218F7FF4A697D /* NYTOperatingSystemCompatibilityUtility.h in Headers */,
+				E21038FD1FE8F1F406CD098B /* NYTPhoto.h in Headers */,
+				E5F55694026E98ECD9866856 /* NYTPhotoCaptionView.h in Headers */,
+				70B6FBBC064CC361AB24C0DA /* NYTPhotoContainer.h in Headers */,
+				70548ECADB5332269E65AF4C /* NYTPhotoDismissalInteractionController.h in Headers */,
+				AE3D542786E8E1FF3ADACDE1 /* NYTPhotoTransitionAnimator.h in Headers */,
+				CB6E4EEDCB390C75488510AF /* NYTPhotoTransitionController.h in Headers */,
+				2ABC4C2AE43F6DAD3A642F57 /* NYTPhotoViewController.h in Headers */,
+				E48EDDF4E40CB5C5ECA925BB /* NYTPhotosDataSource.h in Headers */,
+				B55134BD22538F5C7D0AACBD /* NYTPhotosOverlayView.h in Headers */,
+				6B1C3F40818CBFA16DF95C09 /* NYTPhotosViewController.h in Headers */,
+				E7B376F0E4E7313B48C9B5FD /* NYTPhotosViewControllerDataSource.h in Headers */,
+				BDB99FA97F7D612B728DBA1B /* NYTScalingImageView.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2A81BD081B56F91100EE971C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2A81BD2E1B56F91E00EE971C /* NYTPhotoTransitionController.h in Headers */,
+				2A81BD391B56F91E00EE971C /* NYTScalingImageView.h in Headers */,
+				2A81BD2A1B56F91E00EE971C /* NYTPhotoDismissalInteractionController.h in Headers */,
+				2A81BD101B56F91100EE971C /* NYTPhotoViewer.h in Headers */,
+				2A81BD381B56F91E00EE971C /* NYTPhotosViewControllerDataSource.h in Headers */,
+				2A81BD271B56F91E00EE971C /* NYTPhotoCaptionView.h in Headers */,
+				2A81BD341B56F91E00EE971C /* NYTPhotosOverlayView.h in Headers */,
+				2A81BD291B56F91E00EE971C /* NYTPhotoContainer.h in Headers */,
+				2A81BD261B56F91E00EE971C /* NYTPhoto.h in Headers */,
+				2A81BD321B56F91E00EE971C /* NYTPhotosDataSource.h in Headers */,
+				2A81BD2C1B56F91E00EE971C /* NYTPhotoTransitionAnimator.h in Headers */,
+				2A81BD301B56F91E00EE971C /* NYTPhotoViewController.h in Headers */,
+				2A81BD361B56F91E00EE971C /* NYTPhotosViewController.h in Headers */,
+				2A81BD241B56F91E00EE971C /* NYTOperatingSystemCompatibilityUtility.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9080749D52787FEA52932EC3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				56C60D5C34B45096E13A4ABE /* NYTOperatingSystemCompatibilityUtility.h in Headers */,
+				AA8E4B00B7D93C4345BDBC03 /* NYTPhoto.h in Headers */,
+				99EDE1F605E9270D670B70C1 /* NYTPhotoCaptionView.h in Headers */,
+				7DCF3F784593A0129B36C179 /* NYTPhotoContainer.h in Headers */,
+				51091C5B419F91900ED19FB5 /* NYTPhotoDismissalInteractionController.h in Headers */,
+				AB2D2BDDCB26DB31EADE1EA4 /* NYTPhotoTransitionAnimator.h in Headers */,
+				760590D187902346DB2BCFC9 /* NYTPhotoTransitionController.h in Headers */,
+				976E372E2004153FD3F85890 /* NYTPhotoViewController.h in Headers */,
+				D89EBF50F6B5D580566FEAC5 /* NYTPhotosDataSource.h in Headers */,
+				5236B10EF0CBE94BF253E91A /* NYTPhotosOverlayView.h in Headers */,
+				4F69D2808E42983BA8814A4B /* NYTPhotosViewController.h in Headers */,
+				39870B1D6DB0C778CBF6D749 /* NYTPhotosViewControllerDataSource.h in Headers */,
+				4570C9B61E0DA14C7E9C319B /* NYTScalingImageView.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A6B20E0E7794E652E5306DA /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				59865BA3CD478F735ABC11FC /* NSInvocation+OCMAdditions.h in Headers */,
+				D8EC2EE0938292DEF26EA394 /* NSMethodSignature+OCMAdditions.h in Headers */,
+				62EEDDBF2AA6D86E983BF726 /* NSNotificationCenter+OCMAdditions.h in Headers */,
+				9A1D8FF3FECAE266DF1919F9 /* NSObject+OCMAdditions.h in Headers */,
+				89FB1B1782E6BFD561C3CD14 /* NSValue+OCMAdditions.h in Headers */,
+				1B53F2FDEF2057318516A931 /* OCClassMockObject.h in Headers */,
+				FBA5E233A118EFFE1233BD71 /* OCMArg.h in Headers */,
+				C4C1D864972C9E7744269700 /* OCMBlockCaller.h in Headers */,
+				0164B49DEBF3FD09112BAF54 /* OCMBoxedReturnValueProvider.h in Headers */,
+				E71C3BB6E5CB1528E12A96A3 /* OCMConstraint.h in Headers */,
+				2AB8C29105D31E289D65839B /* OCMExceptionReturnValueProvider.h in Headers */,
+				2FCC37CD4A39646933819732 /* OCMExpectationRecorder.h in Headers */,
+				ACEE50D48728EEB5F8354922 /* OCMFunctions.h in Headers */,
+				BAC56D667FF286D6330E4FE0 /* OCMIndirectReturnValueProvider.h in Headers */,
+				49DE14448904B4D3FBDE54A6 /* OCMInvocationExpectation.h in Headers */,
+				41A2D01B9AE6B55D4CB54B89 /* OCMInvocationMatcher.h in Headers */,
+				F2D49A50BCDAB974F67D4CF2 /* OCMInvocationStub.h in Headers */,
+				1B588B1D79BF7E420074A990 /* OCMLocation.h in Headers */,
+				91824627BDD99B2A2A6C3C99 /* OCMMacroState.h in Headers */,
+				C16378DE0EAF98AB527A74BE /* OCMNotificationPoster.h in Headers */,
+				F8D52EC26C2F32AAA5DFA3B2 /* OCMObserverRecorder.h in Headers */,
+				CD9741B7AE164912BECE1F01 /* OCMPassByRefSetter.h in Headers */,
+				C0D0820115B685438F44A32B /* OCMRealObjectForwarder.h in Headers */,
+				F7E5179949F07ED158C3C824 /* OCMRecorder.h in Headers */,
+				22A1B39DABC21B6183F22CCB /* OCMReturnValueProvider.h in Headers */,
+				5E6E75B60A5A6C24DC969089 /* OCMStubRecorder.h in Headers */,
+				ED57D537BB3EB8AD68D997C0 /* OCMVerifier.h in Headers */,
+				64F4BC5C2509CE1E037C55C2 /* OCMock.h in Headers */,
+				37F8EDFD997F8B953C6B679A /* OCMockObject.h in Headers */,
+				4807A4121C26FE5BBFB5BBDB /* OCObserverMockObject.h in Headers */,
+				6BC0C426D4F00674C04F48E0 /* OCPartialMockObject.h in Headers */,
+				DDB89B3EFA729D467B4CEC86 /* OCProtocolMockObject.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CEBDB13E5A86E6C704C84944 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0CBCEC4163FB3ADE88A24B80 /* NYTOperatingSystemCompatibilityUtility.h in Headers */,
+				C9600506CAF4F1B41F3C8435 /* NYTPhoto.h in Headers */,
+				32CD52FD28A787B9FE09E9F4 /* NYTPhotoCaptionView.h in Headers */,
+				BEEB5CDD41FFE788B7B0ADBB /* NYTPhotoContainer.h in Headers */,
+				BACF355C620F956C3380C7D6 /* NYTPhotoDismissalInteractionController.h in Headers */,
+				F6AF54630700F5E9C5C2CC7D /* NYTPhotoTransitionAnimator.h in Headers */,
+				06DA2E7E2D69F82C0A3DA20C /* NYTPhotoTransitionController.h in Headers */,
+				B22382FAC747585AFC66A1A0 /* NYTPhotoViewController.h in Headers */,
+				D9820C3FB72CA3E883C794B6 /* NYTPhotosDataSource.h in Headers */,
+				7B54D14A71AB5B0F16465842 /* NYTPhotosOverlayView.h in Headers */,
+				ECFD0B9B4877B1B42B71F472 /* NYTPhotosViewController.h in Headers */,
+				183BB060A9ADD0F503B6B2DA /* NYTPhotosViewControllerDataSource.h in Headers */,
+				9066D53EDD0479E5742F0631 /* NYTScalingImageView.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DD996922D0E95E131F95FF1D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				70AA19CBF91B6EC6A634A222 /* NSInvocation+OCMAdditions.h in Headers */,
+				D53D752AF09654956A95CB44 /* NSMethodSignature+OCMAdditions.h in Headers */,
+				C11D170EA81F64A153CC4248 /* NSNotificationCenter+OCMAdditions.h in Headers */,
+				E20E6ECED2388FC746048E77 /* NSObject+OCMAdditions.h in Headers */,
+				8EDBA5F0FCBCCED6E39BEEA1 /* NSValue+OCMAdditions.h in Headers */,
+				43C3CE9C3E3BC3BE4E3A1E16 /* OCClassMockObject.h in Headers */,
+				C8418D3444A8D2C48151B255 /* OCMArg.h in Headers */,
+				40C977BD65720FB89A08A869 /* OCMBlockCaller.h in Headers */,
+				152A783F03F3584D6CF20251 /* OCMBoxedReturnValueProvider.h in Headers */,
+				26DCE245D3925CEB3A8D0FDB /* OCMConstraint.h in Headers */,
+				015E0414AD24281005E5750C /* OCMExceptionReturnValueProvider.h in Headers */,
+				0B77D3608D09516179FFEDC8 /* OCMExpectationRecorder.h in Headers */,
+				948C084D5D6EF42AF89FB510 /* OCMFunctions.h in Headers */,
+				F0F1A28D19832F854C732D1E /* OCMIndirectReturnValueProvider.h in Headers */,
+				94076555791A8A5E89ACC230 /* OCMInvocationExpectation.h in Headers */,
+				F2AB71D4DAF54BFD1B1FA44E /* OCMInvocationMatcher.h in Headers */,
+				E063BC2BB5F0A56E31D6C061 /* OCMInvocationStub.h in Headers */,
+				1A5CE29D7708C2092B5F0082 /* OCMLocation.h in Headers */,
+				8B8D98DF6B861C3866837A92 /* OCMMacroState.h in Headers */,
+				663FEDC2F9ED56FA60E637DD /* OCMNotificationPoster.h in Headers */,
+				D5CD36836C52834E1C11C329 /* OCMObserverRecorder.h in Headers */,
+				EDE4D8460746F33533829640 /* OCMPassByRefSetter.h in Headers */,
+				636F3908B0DF40628CA7D3F8 /* OCMRealObjectForwarder.h in Headers */,
+				2F8AA59CA858EB5DA740B810 /* OCMRecorder.h in Headers */,
+				DC79D46F4D4D676614C38DAA /* OCMReturnValueProvider.h in Headers */,
+				B1BE80CC0876C7C8D948CC30 /* OCMStubRecorder.h in Headers */,
+				2F54BB8FA3B465875CA7D6F7 /* OCMVerifier.h in Headers */,
+				14C54B648E45B84FB7ADF9D4 /* OCMock.h in Headers */,
+				87D7512B79AA4C9ECA874EB2 /* OCMockObject.h in Headers */,
+				139760EB2F3134E3C8A0510C /* OCObserverMockObject.h in Headers */,
+				3CC92C10E7DBA6CBF22A489F /* OCPartialMockObject.h in Headers */,
+				5AF80A29F00DCD3525E738E7 /* OCProtocolMockObject.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F3CDC348008DF5B1BB750686 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4D9C87316D51A3019812E812 /* NYTOperatingSystemCompatibilityUtility.h in Headers */,
+				C32125E4A6AF66AA52B71B95 /* NYTPhoto.h in Headers */,
+				781B44CA573D65EFEDB7ED86 /* NYTPhotoCaptionView.h in Headers */,
+				292D2375F2BD26E146CDD68D /* NYTPhotoContainer.h in Headers */,
+				6B058507325AC4344802BBCE /* NYTPhotoDismissalInteractionController.h in Headers */,
+				C52ABCCFDD6F6C846C66BC06 /* NYTPhotoTransitionAnimator.h in Headers */,
+				D3E3AEE239D58900B1A098AB /* NYTPhotoTransitionController.h in Headers */,
+				54E7CC5695D31BC468B4689E /* NYTPhotoViewController.h in Headers */,
+				918FD1D39CB234CB639D33EC /* NYTPhotosDataSource.h in Headers */,
+				88FFB8E8CE680E58AE696CD7 /* NYTPhotosOverlayView.h in Headers */,
+				F7573D629803B18E179098C1 /* NYTPhotosViewController.h in Headers */,
+				FACF10EE9495312E24A39A24 /* NYTPhotosViewControllerDataSource.h in Headers */,
+				25A6643BB2363320A15111E8 /* NYTScalingImageView.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		0447139662D4FCA4E4612E05 /* Pods-Tests-NYTPhotoViewer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6400B340CB182C73CFF3DF39 /* Build configuration list for PBXNativeTarget "Pods-Tests-NYTPhotoViewer" */;
+			buildPhases = (
+				3AA9A0E8AB197C15D58851E0 /* Sources */,
+				7EC47F014DF1D58DA8A1DE1E /* Frameworks */,
+				1334361CABA6075E465C7832 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-Tests-NYTPhotoViewer";
+			productName = "Pods-Tests-NYTPhotoViewer";
+			productReference = 8B0ACC9B5708AD621EE5F694 /* libPods-Tests-NYTPhotoViewer.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		09DE7D921811F6AD29841E02 /* Pods-NYTPhotoViewer-Swift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 36A2A63B1279C7FA8CDC9145 /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer-Swift" */;
+			buildPhases = (
+				7C79097821A783E5E40B9721 /* Sources */,
+				0B7EC604A48FA1C304C0F7CC /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3A2C5BC40053F03AB7B173E8 /* PBXTargetDependency */,
+			);
+			name = "Pods-NYTPhotoViewer-Swift";
+			productName = "Pods-NYTPhotoViewer-Swift";
+			productReference = D68D0582B96DB4EDB28B7091 /* libPods-NYTPhotoViewer-Swift.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		2104855B84EF13FE632EC212 /* Pods-NYTPhotoViewer-SwiftTests-OCMock */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DF9B79E0887A8BA249670C1B /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer-SwiftTests-OCMock" */;
+			buildPhases = (
+				454140A94EADE7E64927003D /* Sources */,
+				4F8314F6055C7954A72B9B51 /* Frameworks */,
+				DD996922D0E95E131F95FF1D /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-NYTPhotoViewer-SwiftTests-OCMock";
+			productName = "Pods-NYTPhotoViewer-SwiftTests-OCMock";
+			productReference = CF7C82773CF45E8ABC34D9BC /* libPods-NYTPhotoViewer-SwiftTests-OCMock.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		2A81BD0A1B56F91100EE971C /* NYTPhotoViewer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2A81BD221B56F91100EE971C /* Build configuration list for PBXNativeTarget "NYTPhotoViewer" */;
+			buildPhases = (
+				2A81BD061B56F91100EE971C /* Sources */,
+				2A81BD071B56F91100EE971C /* Frameworks */,
+				2A81BD081B56F91100EE971C /* Headers */,
+				2A81BD091B56F91100EE971C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NYTPhotoViewer;
+			productName = NYTPhotoViewer;
+			productReference = 2A81BD0B1B56F91100EE971C /* NYTPhotoViewer.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		2A81BD141B56F91100EE971C /* NYTPhotoViewerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2A81BD231B56F91100EE971C /* Build configuration list for PBXNativeTarget "NYTPhotoViewerTests" */;
+			buildPhases = (
+				2A81BD111B56F91100EE971C /* Sources */,
+				2A81BD121B56F91100EE971C /* Frameworks */,
+				2A81BD131B56F91100EE971C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2A81BD181B56F91100EE971C /* PBXTargetDependency */,
+			);
+			name = NYTPhotoViewerTests;
+			productName = NYTPhotoViewerTests;
+			productReference = 2A81BD151B56F91100EE971C /* NYTPhotoViewerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		5D82D542EF99743A8B00FCE3 /* Pods-NYTPhotoViewer-NYTPhotoViewer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 25009C60EF8844370FDAB21D /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer-NYTPhotoViewer" */;
+			buildPhases = (
+				9D0B26B886340FEDD42C3E21 /* Sources */,
+				2666B9448C8F921C33BDE958 /* Frameworks */,
+				F3CDC348008DF5B1BB750686 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-NYTPhotoViewer-NYTPhotoViewer";
+			productName = "Pods-NYTPhotoViewer-NYTPhotoViewer";
+			productReference = 9780D65FCFCBFB28EAB66199 /* libPods-NYTPhotoViewer-NYTPhotoViewer.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		85E8BD93A66999131D97D401 /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A8C18131BB772509B70A9B7D /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer-Swift-NYTPhotoViewer" */;
+			buildPhases = (
+				3EA0E04E44A11259FD882560 /* Sources */,
+				95E635757BB30FAC83F6C156 /* Frameworks */,
+				9080749D52787FEA52932EC3 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-NYTPhotoViewer-Swift-NYTPhotoViewer";
+			productName = "Pods-NYTPhotoViewer-Swift-NYTPhotoViewer";
+			productReference = 74FFAEFFFD2054400CC52B43 /* libPods-NYTPhotoViewer-Swift-NYTPhotoViewer.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		A15831F42ECC7BF14C293DE2 /* Pods-NYTPhotoViewer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3FDB77D8C6B477F56F7331F9 /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer" */;
+			buildPhases = (
+				7C54572B7B7AE9D54D75486F /* Sources */,
+				68369090B42B85AEAB024660 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				23EB7844D274BDFC2579DE6D /* PBXTargetDependency */,
+			);
+			name = "Pods-NYTPhotoViewer";
+			productName = "Pods-NYTPhotoViewer";
+			productReference = 5A0B46673310BD28D06AE956 /* libPods-NYTPhotoViewer.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		DACEF04843F4D3AAB41E45B9 /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CC241B9D4900E0BAC7643572 /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer" */;
+			buildPhases = (
+				BCA6F469A10130F901ECA84D /* Sources */,
+				1DA147F57555614CEA3BA0A2 /* Frameworks */,
+				CEBDB13E5A86E6C704C84944 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer";
+			productName = "Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer";
+			productReference = 11D73809917EC52B050827A3 /* libPods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		E0ED2EDB9A6415A056DE5CFB /* Pods-Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A3C38321E78A8DD16837EC35 /* Build configuration list for PBXNativeTarget "Pods-Tests" */;
+			buildPhases = (
+				DFF18B0468F16A6093E25876 /* Sources */,
+				F28E2AFACDB161074E8DEEE3 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				99C41C502164EF6C5DDCB7AE /* PBXTargetDependency */,
+				44CEC4D954815E90731BFC57 /* PBXTargetDependency */,
+			);
+			name = "Pods-Tests";
+			productName = "Pods-Tests";
+			productReference = 3B934FCE1F8716091A32FE81 /* libPods-Tests.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		F2877E4932031B6DB35FA0E3 /* Pods-NYTPhotoViewer-SwiftTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2D934C00AA62DB623AA053F1 /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer-SwiftTests" */;
+			buildPhases = (
+				3A3E3E8BD2CCF57F7617CC42 /* Sources */,
+				E0F9E06D4BD660FA010FF66E /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				299B3FFF8FBAB1C3DBCE9236 /* PBXTargetDependency */,
+				CCE66B93D04970FE98EA21DC /* PBXTargetDependency */,
+			);
+			name = "Pods-NYTPhotoViewer-SwiftTests";
+			productName = "Pods-NYTPhotoViewer-SwiftTests";
+			productReference = 806A3C92AC1C8976713B07B4 /* libPods-NYTPhotoViewer-SwiftTests.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		FB47254A4055AE3C774C5CF8 /* Pods-Tests-OCMock */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DBAF899A63B79796E5009645 /* Build configuration list for PBXNativeTarget "Pods-Tests-OCMock" */;
+			buildPhases = (
+				1D424E9C9915DD35D0596789 /* Sources */,
+				161E063BBEF3983A7CCF5C34 /* Frameworks */,
+				9A6B20E0E7794E652E5306DA /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-Tests-OCMock";
+			productName = "Pods-Tests-OCMock";
+			productReference = 75E0863BEC7C298CA54E0C41 /* libPods-Tests-OCMock.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		DB3F5DC7DE66FB7274E6FB52 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0510;
+				TargetAttributes = {
+					2A81BD0A1B56F91100EE971C = {
+						CreatedOnToolsVersion = 6.4;
+					};
+					2A81BD141B56F91100EE971C = {
+						CreatedOnToolsVersion = 6.4;
+					};
+				};
+			};
+			buildConfigurationList = 842A2075DABDAF0691AA7D0E /* Build configuration list for PBXProject "Pods" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 300D825A591949CAB22D43DF;
+			productRefGroup = 7C0F5C2FCCF6271836A3C232 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A15831F42ECC7BF14C293DE2 /* Pods-NYTPhotoViewer */,
+				5D82D542EF99743A8B00FCE3 /* Pods-NYTPhotoViewer-NYTPhotoViewer */,
+				09DE7D921811F6AD29841E02 /* Pods-NYTPhotoViewer-Swift */,
+				85E8BD93A66999131D97D401 /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer */,
+				F2877E4932031B6DB35FA0E3 /* Pods-NYTPhotoViewer-SwiftTests */,
+				DACEF04843F4D3AAB41E45B9 /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer */,
+				2104855B84EF13FE632EC212 /* Pods-NYTPhotoViewer-SwiftTests-OCMock */,
+				E0ED2EDB9A6415A056DE5CFB /* Pods-Tests */,
+				0447139662D4FCA4E4612E05 /* Pods-Tests-NYTPhotoViewer */,
+				FB47254A4055AE3C774C5CF8 /* Pods-Tests-OCMock */,
+				2A81BD0A1B56F91100EE971C /* NYTPhotoViewer */,
+				2A81BD141B56F91100EE971C /* NYTPhotoViewerTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		2A81BD091B56F91100EE971C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2A81BD131B56F91100EE971C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1D424E9C9915DD35D0596789 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9B9C54F6E71DF765B769FF6A /* NSInvocation+OCMAdditions.m in Sources */,
+				323B0BCDA6BE5B1ACBCE77AD /* NSMethodSignature+OCMAdditions.m in Sources */,
+				4D84B0B1828FF9F17EAE72CF /* NSNotificationCenter+OCMAdditions.m in Sources */,
+				3B0D1B05A7A7796A3CB8ED8F /* NSObject+OCMAdditions.m in Sources */,
+				C0433EC9D69288656B8A48D0 /* NSValue+OCMAdditions.m in Sources */,
+				B44CD330DF715C17F797AA32 /* OCClassMockObject.m in Sources */,
+				12CF97F49B80D0A051FE1DB0 /* OCMArg.m in Sources */,
+				04D5496729A0A1C3E445CCC5 /* OCMBlockCaller.m in Sources */,
+				F2A7FC568E8088E471D860EE /* OCMBoxedReturnValueProvider.m in Sources */,
+				E3BC1B85323AEDDC9FF2FEA2 /* OCMConstraint.m in Sources */,
+				43399EC15351453AE666AECD /* OCMExceptionReturnValueProvider.m in Sources */,
+				689FDA306464A152F43FD1F5 /* OCMExpectationRecorder.m in Sources */,
+				3772E7EEE6AB6D00D9F331AB /* OCMFunctions.m in Sources */,
+				BED3EC187AD227769E074EF8 /* OCMIndirectReturnValueProvider.m in Sources */,
+				1A1DE934D733864D4FEEA162 /* OCMInvocationExpectation.m in Sources */,
+				46E6EFF02357FC93AF696272 /* OCMInvocationMatcher.m in Sources */,
+				D8CDD718588A07F65EFC97E3 /* OCMInvocationStub.m in Sources */,
+				118F763BC48FEFB7DFA68BF4 /* OCMLocation.m in Sources */,
+				3DB3A1DF322DB3431EA27904 /* OCMMacroState.m in Sources */,
+				9231A601A6094B3BBBB3C1B1 /* OCMNotificationPoster.m in Sources */,
+				25CD1295ABE755C4EA757857 /* OCMObserverRecorder.m in Sources */,
+				780B3D1D92E1C2E92E6C1B6B /* OCMPassByRefSetter.m in Sources */,
+				7E16BF7E80E66C9BAA600481 /* OCMRealObjectForwarder.m in Sources */,
+				BCF5CF2871A2C6A8BE39E35E /* OCMRecorder.m in Sources */,
+				8F204A9D76A8F45D856BE530 /* OCMReturnValueProvider.m in Sources */,
+				601C21199EE2C1DFA1BCB15C /* OCMStubRecorder.m in Sources */,
+				738FD3CA96D7B232D196DF3D /* OCMVerifier.m in Sources */,
+				3D17549A57BFCE5295C87035 /* OCMockObject.m in Sources */,
+				B337DC4CDE59F58D6651F43D /* OCObserverMockObject.m in Sources */,
+				0F5F94B5A5F9332D4C8A32C9 /* OCPartialMockObject.m in Sources */,
+				A4CFAA11A09B96994A21D71B /* OCProtocolMockObject.m in Sources */,
+				BC70C00E99E3001779951F4F /* Pods-Tests-OCMock-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2A81BD061B56F91100EE971C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2A81BD281B56F91E00EE971C /* NYTPhotoCaptionView.m in Sources */,
+				2A81BD331B56F91E00EE971C /* NYTPhotosDataSource.m in Sources */,
+				2A81BD2F1B56F91E00EE971C /* NYTPhotoTransitionController.m in Sources */,
+				2A81BD2B1B56F91E00EE971C /* NYTPhotoDismissalInteractionController.m in Sources */,
+				2A81BD2D1B56F91E00EE971C /* NYTPhotoTransitionAnimator.m in Sources */,
+				2A81BD251B56F91E00EE971C /* NYTOperatingSystemCompatibilityUtility.m in Sources */,
+				2A81BD3A1B56F91E00EE971C /* NYTScalingImageView.m in Sources */,
+				2A81BD351B56F91E00EE971C /* NYTPhotosOverlayView.m in Sources */,
+				2A81BD371B56F91E00EE971C /* NYTPhotosViewController.m in Sources */,
+				2A81BD311B56F91E00EE971C /* NYTPhotoViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2A81BD111B56F91100EE971C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2A81BD1D1B56F91100EE971C /* NYTPhotoViewerTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3A3E3E8BD2CCF57F7617CC42 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8229F2538A10468699323314 /* Pods-NYTPhotoViewer-SwiftTests-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AA9A0E8AB197C15D58851E0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2A1225DA14A462FFEF175AB9 /* NYTOperatingSystemCompatibilityUtility.m in Sources */,
+				E884CCF2E609A2DF4B799FA1 /* NYTPhotoCaptionView.m in Sources */,
+				056829D68A120794CCC55FB1 /* NYTPhotoDismissalInteractionController.m in Sources */,
+				DD68A2A3D11BE1C6A3C0B1C3 /* NYTPhotoTransitionAnimator.m in Sources */,
+				2A0999B262595827E16E7A01 /* NYTPhotoTransitionController.m in Sources */,
+				2561273CB0CA8D9EA96CD557 /* NYTPhotoViewController.m in Sources */,
+				36C743ADC61B5F76231EE2BC /* NYTPhotosDataSource.m in Sources */,
+				278F689B521DD0D500FE4F99 /* NYTPhotosOverlayView.m in Sources */,
+				4D59AED6FC23CA17EA99640F /* NYTPhotosViewController.m in Sources */,
+				BABDAC7DF5EC609B14B5E411 /* NYTScalingImageView.m in Sources */,
+				F7EF061A03591B3255B1B664 /* Pods-Tests-NYTPhotoViewer-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3EA0E04E44A11259FD882560 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1E35AE8BC3084101DDD5EE82 /* NYTOperatingSystemCompatibilityUtility.m in Sources */,
+				32C7B0E6AF799371FE62B0D5 /* NYTPhotoCaptionView.m in Sources */,
+				151D006F83A16AB3332DB9CC /* NYTPhotoDismissalInteractionController.m in Sources */,
+				D28B95ECC09DA0CE5B579F77 /* NYTPhotoTransitionAnimator.m in Sources */,
+				16DB23E61ADCB20BC55D5D13 /* NYTPhotoTransitionController.m in Sources */,
+				F824173726541D181A9D00F3 /* NYTPhotoViewController.m in Sources */,
+				BD575CDF7A4663127252C464 /* NYTPhotosDataSource.m in Sources */,
+				37A004E5CFC5AA9A094FD1C5 /* NYTPhotosOverlayView.m in Sources */,
+				9E635BC1289151E5254E4293 /* NYTPhotosViewController.m in Sources */,
+				909C6DB1829CB8D53D6B5BE9 /* NYTScalingImageView.m in Sources */,
+				F13A62CD6E12E5F145564A34 /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		454140A94EADE7E64927003D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7565230DB6A9620A1B094C7A /* NSInvocation+OCMAdditions.m in Sources */,
+				BC5143A55B56BDE2D80E6A12 /* NSMethodSignature+OCMAdditions.m in Sources */,
+				6739E028DAF5E977D978AB7A /* NSNotificationCenter+OCMAdditions.m in Sources */,
+				9D9A5BBD65D25652683834AC /* NSObject+OCMAdditions.m in Sources */,
+				3F85EA81252940DEB00FC1FC /* NSValue+OCMAdditions.m in Sources */,
+				FAD8B38EA65866441107E950 /* OCClassMockObject.m in Sources */,
+				59C9858A15A458265D64BEEF /* OCMArg.m in Sources */,
+				55D054D2215886D0B1033FED /* OCMBlockCaller.m in Sources */,
+				A1988ACB88F28CCC5823DFBE /* OCMBoxedReturnValueProvider.m in Sources */,
+				B03A7AADC52213AF71F0EDC6 /* OCMConstraint.m in Sources */,
+				AEE254640D562C309A321B2E /* OCMExceptionReturnValueProvider.m in Sources */,
+				681441754AB5D7DF127B43C4 /* OCMExpectationRecorder.m in Sources */,
+				916E3295F81C6B45837EC1F2 /* OCMFunctions.m in Sources */,
+				9A3F5151AC6022733CA55E91 /* OCMIndirectReturnValueProvider.m in Sources */,
+				DF9044770C313D9F1904ACD9 /* OCMInvocationExpectation.m in Sources */,
+				808E08A0BA8F7D4F170C35FE /* OCMInvocationMatcher.m in Sources */,
+				B5C4557DF08FC40123B38F31 /* OCMInvocationStub.m in Sources */,
+				7968FC48DFDA1B3785F73F4B /* OCMLocation.m in Sources */,
+				7830C2949BA1CB606CEF70CE /* OCMMacroState.m in Sources */,
+				E830C9BDACBD1C723C425830 /* OCMNotificationPoster.m in Sources */,
+				3A344E6D9333FED65A6300C8 /* OCMObserverRecorder.m in Sources */,
+				0F7D347C6001BA07836F5F26 /* OCMPassByRefSetter.m in Sources */,
+				DB4D965D38C629A155F92D11 /* OCMRealObjectForwarder.m in Sources */,
+				A260D88C2C987B8BD4191BA5 /* OCMRecorder.m in Sources */,
+				0E763D8CB6064F5D1EFF7599 /* OCMReturnValueProvider.m in Sources */,
+				36B833681C4F076BF56FCEBB /* OCMStubRecorder.m in Sources */,
+				F19C5AD4A4FA60B998AE3EDE /* OCMVerifier.m in Sources */,
+				C0549C6ED28303D10857AE69 /* OCMockObject.m in Sources */,
+				A0BE4398BA32F3162D9D6562 /* OCObserverMockObject.m in Sources */,
+				05066F08A4081B2ADC64BFD6 /* OCPartialMockObject.m in Sources */,
+				FE1595AC8EBB317AA93524E4 /* OCProtocolMockObject.m in Sources */,
+				21A88F51F216B0659EB3B76A /* Pods-NYTPhotoViewer-SwiftTests-OCMock-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7C54572B7B7AE9D54D75486F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4F27CB1D26F356F78CFD3D06 /* Pods-NYTPhotoViewer-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7C79097821A783E5E40B9721 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9073322179745DC90D4B1394 /* Pods-NYTPhotoViewer-Swift-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9D0B26B886340FEDD42C3E21 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD81BE22F42799FEA42A0ADD /* NYTOperatingSystemCompatibilityUtility.m in Sources */,
+				C182E01E0A7EC5A4484C4B41 /* NYTPhotoCaptionView.m in Sources */,
+				B7FC7819993344BCA62B186E /* NYTPhotoDismissalInteractionController.m in Sources */,
+				EB03C6769464BB66A4DC65C3 /* NYTPhotoTransitionAnimator.m in Sources */,
+				9F2E72395D58FAE18BA21DA7 /* NYTPhotoTransitionController.m in Sources */,
+				7EB9E346E3DA38232A849273 /* NYTPhotoViewController.m in Sources */,
+				CBA53F104597B700D89B97CE /* NYTPhotosDataSource.m in Sources */,
+				A308017BF4CCA6DC097E201A /* NYTPhotosOverlayView.m in Sources */,
+				E7BF65213D7FBC77F8FF1363 /* NYTPhotosViewController.m in Sources */,
+				DE0AC62E6C5E4576E1752919 /* NYTScalingImageView.m in Sources */,
+				2CC43C113F8A24E48629AC04 /* Pods-NYTPhotoViewer-NYTPhotoViewer-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BCA6F469A10130F901ECA84D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				93188388DFD83F2E61EC26E8 /* NYTOperatingSystemCompatibilityUtility.m in Sources */,
+				607AF39C3A9F35E619C2C5C2 /* NYTPhotoCaptionView.m in Sources */,
+				6EEBAFE78B2CF2AF801D6733 /* NYTPhotoDismissalInteractionController.m in Sources */,
+				58CC19214E17AD160D44D4DD /* NYTPhotoTransitionAnimator.m in Sources */,
+				E2140C737209892D3F8C460F /* NYTPhotoTransitionController.m in Sources */,
+				C3DD6609296FBEB3E529A01B /* NYTPhotoViewController.m in Sources */,
+				EB3F8ABB51CBE9292B3A8E08 /* NYTPhotosDataSource.m in Sources */,
+				B8ECEB7C3984D842060812B7 /* NYTPhotosOverlayView.m in Sources */,
+				2B251A189EC557DDDDDA469E /* NYTPhotosViewController.m in Sources */,
+				2C05312A1C90F8175B932164 /* NYTScalingImageView.m in Sources */,
+				DFF2FC54C20ADD0E8CF29271 /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DFF18B0468F16A6093E25876 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6ED37D4D6BF570E74AFE83F7 /* Pods-Tests-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		23EB7844D274BDFC2579DE6D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-NYTPhotoViewer-NYTPhotoViewer";
+			target = 5D82D542EF99743A8B00FCE3 /* Pods-NYTPhotoViewer-NYTPhotoViewer */;
+			targetProxy = 108E73A754727909F32E6567 /* PBXContainerItemProxy */;
+		};
+		299B3FFF8FBAB1C3DBCE9236 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer";
+			target = DACEF04843F4D3AAB41E45B9 /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer */;
+			targetProxy = F5BB7526AE1EB62A063D4BB7 /* PBXContainerItemProxy */;
+		};
+		2A81BD181B56F91100EE971C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2A81BD0A1B56F91100EE971C /* NYTPhotoViewer */;
+			targetProxy = 2A81BD171B56F91100EE971C /* PBXContainerItemProxy */;
+		};
+		3A2C5BC40053F03AB7B173E8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-NYTPhotoViewer-Swift-NYTPhotoViewer";
+			target = 85E8BD93A66999131D97D401 /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer */;
+			targetProxy = 648B76D2318B3F724FE5AFAE /* PBXContainerItemProxy */;
+		};
+		44CEC4D954815E90731BFC57 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-Tests-OCMock";
+			target = FB47254A4055AE3C774C5CF8 /* Pods-Tests-OCMock */;
+			targetProxy = 456ADE491FA4A185969E5BDD /* PBXContainerItemProxy */;
+		};
+		99C41C502164EF6C5DDCB7AE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-Tests-NYTPhotoViewer";
+			target = 0447139662D4FCA4E4612E05 /* Pods-Tests-NYTPhotoViewer */;
+			targetProxy = 2D126C1BB9864B0106EE5884 /* PBXContainerItemProxy */;
+		};
+		CCE66B93D04970FE98EA21DC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-NYTPhotoViewer-SwiftTests-OCMock";
+			target = 2104855B84EF13FE632EC212 /* Pods-NYTPhotoViewer-SwiftTests-OCMock */;
+			targetProxy = EEEA7EBB25EF27D55ABA4FD6 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		04F6115BDEC2C660AD6CEEFC /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 66D75152ED32E28D2FCE0ABE /* Pods-NYTPhotoViewer-Swift.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		12143D2710B60903918956F7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7F67EE3634297DF862DA26A1 /* Pods-NYTPhotoViewer-SwiftTests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		18E7BE82797F36BC7315A524 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E2E4B5C18DCD84D83B675BEF /* Pods-NYTPhotoViewer.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		2A66465343511DE9BFA03B77 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3669B7BC097736BFF008062A /* Pods-NYTPhotoViewer-SwiftTests-OCMock-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-NYTPhotoViewer-SwiftTests-OCMock/Pods-NYTPhotoViewer-SwiftTests-OCMock-prefix.pch";
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		2A81BD1E1B56F91100EE971C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = NYTPhotoViewer/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		2A81BD1F1B56F91100EE971C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = NYTPhotoViewer/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		2A81BD201B56F91100EE971C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = NYTPhotoViewerTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		2A81BD211B56F91100EE971C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = NYTPhotoViewerTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+			};
+			name = Release;
+		};
+		3340CF0CEFCDE830FB2E1835 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3669B7BC097736BFF008062A /* Pods-NYTPhotoViewer-SwiftTests-OCMock-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-NYTPhotoViewer-SwiftTests-OCMock/Pods-NYTPhotoViewer-SwiftTests-OCMock-prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		3496B1C10897E3B078A2373F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 86B43563820BACECDECDBA14 /* Pods-NYTPhotoViewer-NYTPhotoViewer-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-NYTPhotoViewer-NYTPhotoViewer/Pods-NYTPhotoViewer-NYTPhotoViewer-prefix.pch";
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		36D74CC47D031BBCFE491FE9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C9BB0C33DC6D2674A2650FDA /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-prefix.pch";
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		4E428710ECC26D09F7A781A1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F6E67ADB8E8582FDA08A8CBC /* Pods-NYTPhotoViewer-SwiftTests.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		695CE4F613880545ADB04406 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C9BB0C33DC6D2674A2650FDA /* Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer/Pods-NYTPhotoViewer-Swift-NYTPhotoViewer-prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		6AAFD5D3F0224EFC6E97C5E8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6A31E6153B31E5AA4B08F6A1 /* Pods-Tests.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		6DBD7A586D69AB4384FC787E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D111BD4C163B390AEAF136CB /* Pods-Tests-OCMock-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-Tests-OCMock/Pods-Tests-OCMock-prefix.pch";
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		707AB77C486BF42D6CB5EEB4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				STRIP_INSTALLED_PRODUCT = NO;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		7DA238E069D679F3A7D49F19 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				COPY_PHASE_STRIP = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ONLY_ACTIVE_ARCH = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Debug;
+		};
+		84E497D6958F5C7EA9AF407F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 33DB338CD9DE1D0398777F16 /* Pods-Tests-NYTPhotoViewer-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-Tests-NYTPhotoViewer/Pods-Tests-NYTPhotoViewer-prefix.pch";
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		86E991077FF6A2C02EA1D0D1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 16FAD106A2022C3575D8A3AB /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		871DA85373568ABBE7D03370 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D111BD4C163B390AEAF136CB /* Pods-Tests-OCMock-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-Tests-OCMock/Pods-Tests-OCMock-prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		A6576F5C17D55F184B65EB3A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AF43AB7738928F01FCFDF183 /* Pods-NYTPhotoViewer-Swift.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		AB6C47E421D2D896FE250FF1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 33DB338CD9DE1D0398777F16 /* Pods-Tests-NYTPhotoViewer-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-Tests-NYTPhotoViewer/Pods-Tests-NYTPhotoViewer-prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		ACD68F5FDE643665CB9CBD6A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 86B43563820BACECDECDBA14 /* Pods-NYTPhotoViewer-NYTPhotoViewer-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-NYTPhotoViewer-NYTPhotoViewer/Pods-NYTPhotoViewer-NYTPhotoViewer-prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		BF8080268106641E4FF15D47 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E10ACCFC67198E49FA479F63 /* Pods-Tests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		CE87D0F538BC5DA79FC0BB66 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 16FAD106A2022C3575D8A3AB /* Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer/Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer-prefix.pch";
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		FB8D122E5026B28059C55574 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 38622758EBC4096408358F2A /* Pods-NYTPhotoViewer.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				DSTROOT = /tmp/xcodeproj.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_CFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNS_BLOCK_ASSERTIONS=1",
+					"$(inherited)",
+				);
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		25009C60EF8844370FDAB21D /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer-NYTPhotoViewer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ACD68F5FDE643665CB9CBD6A /* Debug */,
+				3496B1C10897E3B078A2373F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2A81BD221B56F91100EE971C /* Build configuration list for PBXNativeTarget "NYTPhotoViewer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2A81BD1E1B56F91100EE971C /* Debug */,
+				2A81BD1F1B56F91100EE971C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		2A81BD231B56F91100EE971C /* Build configuration list for PBXNativeTarget "NYTPhotoViewerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2A81BD201B56F91100EE971C /* Debug */,
+				2A81BD211B56F91100EE971C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		2D934C00AA62DB623AA053F1 /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer-SwiftTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				12143D2710B60903918956F7 /* Debug */,
+				4E428710ECC26D09F7A781A1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		36A2A63B1279C7FA8CDC9145 /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer-Swift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A6576F5C17D55F184B65EB3A /* Debug */,
+				04F6115BDEC2C660AD6CEEFC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3FDB77D8C6B477F56F7331F9 /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				18E7BE82797F36BC7315A524 /* Debug */,
+				FB8D122E5026B28059C55574 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6400B340CB182C73CFF3DF39 /* Build configuration list for PBXNativeTarget "Pods-Tests-NYTPhotoViewer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB6C47E421D2D896FE250FF1 /* Debug */,
+				84E497D6958F5C7EA9AF407F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		842A2075DABDAF0691AA7D0E /* Build configuration list for PBXProject "Pods" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7DA238E069D679F3A7D49F19 /* Debug */,
+				707AB77C486BF42D6CB5EEB4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A3C38321E78A8DD16837EC35 /* Build configuration list for PBXNativeTarget "Pods-Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF8080268106641E4FF15D47 /* Debug */,
+				6AAFD5D3F0224EFC6E97C5E8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A8C18131BB772509B70A9B7D /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer-Swift-NYTPhotoViewer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				695CE4F613880545ADB04406 /* Debug */,
+				36D74CC47D031BBCFE491FE9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CC241B9D4900E0BAC7643572 /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer-SwiftTests-NYTPhotoViewer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				86E991077FF6A2C02EA1D0D1 /* Debug */,
+				CE87D0F538BC5DA79FC0BB66 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DBAF899A63B79796E5009645 /* Build configuration list for PBXNativeTarget "Pods-Tests-OCMock" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				871DA85373568ABBE7D03370 /* Debug */,
+				6DBD7A586D69AB4384FC787E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DF9B79E0887A8BA249670C1B /* Build configuration list for PBXNativeTarget "Pods-NYTPhotoViewer-SwiftTests-OCMock" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3340CF0CEFCDE830FB2E1835 /* Debug */,
+				2A66465343511DE9BFA03B77 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = DB3F5DC7DE66FB7274E6FB52 /* Project object */;
+}

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/NYTPhotoViewer.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/NYTPhotoViewer.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0640"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2A81BD0A1B56F91100EE971C"
+               BuildableName = "NYTPhotoViewer.framework"
+               BlueprintName = "NYTPhotoViewer"
+               ReferencedContainer = "container:Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2A81BD141B56F91100EE971C"
+               BuildableName = "NYTPhotoViewerTests.xctest"
+               BlueprintName = "NYTPhotoViewerTests"
+               ReferencedContainer = "container:Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2A81BD141B56F91100EE971C"
+               BuildableName = "NYTPhotoViewerTests.xctest"
+               BlueprintName = "NYTPhotoViewerTests"
+               ReferencedContainer = "container:Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2A81BD0A1B56F91100EE971C"
+            BuildableName = "NYTPhotoViewer.framework"
+            BlueprintName = "NYTPhotoViewer"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2A81BD0A1B56F91100EE971C"
+            BuildableName = "NYTPhotoViewer.framework"
+            BlueprintName = "NYTPhotoViewer"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2A81BD0A1B56F91100EE971C"
+            BuildableName = "NYTPhotoViewer.framework"
+            BlueprintName = "NYTPhotoViewer"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # NYTPhotoViewer
 
-NYTPhotoViewer is a slideshow and image viewer that includes double tap to zoom, captions, support for multiple images, interactive flick to dismiss, animated zooming presentation, and more. 
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+
+NYTPhotoViewer is a slideshow and image viewer that includes double tap to zoom, captions, support for multiple images, interactive flick to dismiss, animated zooming presentation, and more.
 
 ## Demo
 
@@ -61,7 +63,6 @@ If you experience any interoperability difficulties, please open an issue or pul
 
 * Animate bounds changes like Tweetbot and Facebook.
 * Publicly expose the data source property.
-* [Carthage](https://github.com/Carthage/Carthage) support.
 * An additional sample project written in Swift (currently in pull request).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -21,10 +21,27 @@ NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc]
 
 ## Installation
 
+### CocoaPods
+
 NYTPhotoViewer is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
     pod "NYTPhotoViewer"
+
+### Carthage
+
+NYTPhotoView is also available through [Carthage](http://github.com/carthage/carthage).
+
+You can install Carthage with [Homebrew](http://brew.sh) using the following command
+```bash
+$ brew update
+$ brew install carthage
+```
+
+To add NYTPhotoViewer to your Xcode project using Carthage, add the following line to your `Cartfile`:
+```
+github "NYTimes/NYTPhotoViewer"
+```
 
 ## Requirements
 

--- a/_Pods.xcodeproj
+++ b/_Pods.xcodeproj
@@ -1,0 +1,1 @@
+Example/Pods/Pods.xcodeproj


### PR DESCRIPTION
Adds Carthage support by:

- Adding a framework scheme and sharing it
- Adding a bridging header which includes

``` objc
#import <NYTPhotoViewer/NYTPhotosViewController.h>
#import <NYTPhotoViewer/NYTPhoto.h>
#import <NYTPhotoViewer/NYTPhotosOverlayView.h>
```

- Creating a symlink to the pods project file in the root directory.

### Related Issues

- Closes #61 
- Closes #62 