### PR TITLE
Remove TODO for Swift sample project from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ If you experience any interoperability difficulties, please open an issue or pul
 * Animate bounds changes like Tweetbot and Facebook.
 * Publicly expose the data source property.
 * [Carthage](https://github.com/Carthage/Carthage) support.
-* An additional sample project written in Swift (currently in pull request).
 
 ## License
 


### PR DESCRIPTION
## What it Does

Removes the TODO mentioning Swift sample project from README since this is now in the main branch.

## How to Test

Read over the README, I guess.