### PR TITLE
Fix circular reference of NYTPhotosViewController

### DIFF
--- a/Pod/Classes/ios/NYTPhotoDismissalInteractionController.m
+++ b/Pod/Classes/ios/NYTPhotoDismissalInteractionController.m
@@ -98,7 +98,12 @@ static const CGFloat NYTPhotoDismissalInteractionControllerReturnToCenterVelocit
             self.viewToHideWhenBeginningTransition.hidden = NO;
             
             [self.transitionContext completeTransition:isDismissing && !self.transitionContext.transitionWasCancelled];
+            
+            self.transitionContext = nil;
         }];
+    }
+    else {
+        self.transitionContext = nil;
     }
 }
 


### PR DESCRIPTION
NYTPhotosViewController leaks memory by circular reference around interactive transition.

NYTPhotosViewController is not released when you attempt to dismiss interactively.
That occurs even when transition is canceled. Therefore it leaks by swipe-up/down the picture just once.
(-[NYTPhotosViewController dealloc] is never called.)

## Cause

A concrete class of UIViewControllerContextTransitioning has got view controllers internally as strong reference.

Circular reference appears to be happening as follows:

- NYTPhotosViewController has got NYTPhotoTransitionController
- NYTPhotoTransitionController has got NYTPhotoDismissalInteractionController
- NYTPhotoDismissalInteractionController has got UIViewControllerContextTransitioning
- **UIViewControllerContextTransitioning has got NYTPhotosViewController internally** (*Circular!*)

## Answer

Release NYTPhotoDismissalInteractionController.transitionContext when interactive transition's animation is finished.