### PR TITLE
Fix animated gif does not animate to reference view on dismissal

### DIFF
--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -340,7 +340,7 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtinImageInsets = {3, 0,
 
 - (void)dismissAnimated:(BOOL)animated {
     UIView *startingView;
-    if (self.currentlyDisplayedPhoto.image || self.currentlyDisplayedPhoto.placeholderImage) {
+    if (self.currentlyDisplayedPhoto.image || self.currentlyDisplayedPhoto.placeholderImage || self.currentlyDisplayedPhoto.imageData) {
         startingView = self.currentPhotoViewController.scalingImageView.imageView;
     }
     


### PR DESCRIPTION
@cdzombak this fixes the issue mentioned in https://github.com/atlassian/NYTPhotoViewer/pull/1