### PR TITLE
update overlay information after displaying a photo

### DIFF
--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -323,6 +323,7 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtinImageInsets = {3, 0,
     
     NYTPhotoViewController *photoViewController = [self newPhotoViewControllerForPhoto:photo];
     [self setCurrentlyDisplayedViewController:photoViewController animated:animated];
+    [self updateOverlayInformation];
 }
 
 - (void)updateImageForPhoto:(id <NYTPhoto>)photo {


### PR DESCRIPTION
Update overlay information after displaying a photo to reflect its actual position in the array.

Addresses Issue #99.