### PR TITLE
Fixes a bug when presenting NYTPhotoViewer from a subview of UIStackView

### DIFF
--- a/Pod/Classes/ios/NYTPhotoDismissalInteractionController.m
+++ b/Pod/Classes/ios/NYTPhotoDismissalInteractionController.m
@@ -94,7 +94,7 @@ static const CGFloat NYTPhotoDismissalInteractionControllerReturnToCenterVelocit
                 }
             }
             
-            self.viewToHideWhenBeginningTransition.hidden = NO;
+            self.viewToHideWhenBeginningTransition.alpha = 1.0;
             
             [self.transitionContext completeTransition:isDismissing && !self.transitionContext.transitionWasCancelled];
             
@@ -142,7 +142,7 @@ static const CGFloat NYTPhotoDismissalInteractionControllerReturnToCenterVelocit
 #pragma mark - UIViewControllerInteractiveTransitioning
 
 - (void)startInteractiveTransition:(id <UIViewControllerContextTransitioning>)transitionContext {
-    self.viewToHideWhenBeginningTransition.hidden = YES;
+    self.viewToHideWhenBeginningTransition.alpha = 0.0;
     
     self.transitionContext = transitionContext;
 }

--- a/Pod/Classes/ios/NYTPhotoTransitionAnimator.m
+++ b/Pod/Classes/ios/NYTPhotoTransitionAnimator.m
@@ -137,8 +137,8 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
     [transitionContext.containerView addSubview:endingViewForAnimation];
     
     // Hide the original ending view and starting view until the completion of the animation.
-    self.endingView.hidden = YES;
-    self.startingView.hidden = YES;
+    self.endingView.alpha = 0.0;
+    self.startingView.alpha = 0.0;
     
     CGFloat fadeInDuration = [self transitionDuration:transitionContext] * self.animationDurationEndingViewFadeInRatio;
     CGFloat fadeOutDuration = [self transitionDuration:transitionContext] * self.animationDurationStartingViewFadeOutRatio;
@@ -178,8 +178,8 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
                      }
                      completion:^(BOOL finished) {
                          [endingViewForAnimation removeFromSuperview];
-                         self.endingView.hidden = NO;
-                         self.startingView.hidden = NO;
+                         self.endingView.alpha = 1.0;
+                         self.startingView.alpha = 1.0;
         
                          [self completeTransitionWithTransitionContext:transitionContext];
                      }];


### PR DESCRIPTION
## What it Does

Switches the animated and interactive transition from using `hidden` to `alpha`.

Using `hidden` to control the visibility of `UIView`’s contained in [`UIStackView`](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIStackView_Class_Reference/) has the side effect of affecting the layout of items within the stack view. Setting the view’s `alpha` does not have this
effect.

## How to Test

1. Embed the Image Button in the sample project inside a `UIStackView` including other views.
2. Tap on the Image Button and confirm that the animated presentation and dismissal go to and from the correct frame.

cc @bcapps who co-authored this patch.