### PR TITLE
Better UIImage Support

### DIFF
--- a/Example/NYTPhotoViewer.xcodeproj/project.pbxproj
+++ b/Example/NYTPhotoViewer.xcodeproj/project.pbxproj
@@ -45,7 +45,6 @@
 		B5B252E11A8BE10B00E9973E /* NYTExamplePhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = B5B252E01A8BE10B00E9973E /* NYTExamplePhoto.m */; };
 		B5DC9D821A9D04D300F4F81F /* NYTPhotosViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B5DC9D811A9D04D300F4F81F /* NYTPhotosViewControllerTests.m */; };
 		B5DC9D831A9D062900F4F81F /* NYTExamplePhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = B5B252E01A8BE10B00E9973E /* NYTExamplePhoto.m */; };
-		B5DC9D841A9D092200F4F81F /* NYTViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F5A6195388D20070C39A /* NYTViewController.m */; };
 		B5DC9D871A9D326700F4F81F /* NYTPhotoViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B5DC9D861A9D326700F4F81F /* NYTPhotoViewControllerTests.m */; };
 		B5DC9D891A9D35C500F4F81F /* NYTPhotoCaptionViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B5DC9D881A9D35C500F4F81F /* NYTPhotoCaptionViewTests.m */; };
 		B5DC9D8B1A9F6C9800F4F81F /* NYTPhotosOverlayViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B5DC9D8A1A9F6C9800F4F81F /* NYTPhotosOverlayViewTests.m */; };
@@ -731,7 +730,6 @@
 				B5DC9D831A9D062900F4F81F /* NYTExamplePhoto.m in Sources */,
 				B5DC9D911A9F793200F4F81F /* NYTPhotoTransitionAnimatorTests.m in Sources */,
 				B5DC9D9A1A9FB0C000F4F81F /* NYTPhotosDataSourceTests.m in Sources */,
-				B5DC9D841A9D092200F4F81F /* NYTViewController.m in Sources */,
 				B5DC9D8F1A9F776100F4F81F /* NYTScalingImageViewTests.m in Sources */,
 				B5DC9D821A9D04D300F4F81F /* NYTPhotosViewControllerTests.m in Sources */,
 				B5DC9D871A9D326700F4F81F /* NYTPhotoViewControllerTests.m in Sources */,

--- a/Example/Tests/NYTScalingImageViewTests.m
+++ b/Example/Tests/NYTScalingImageViewTests.m
@@ -24,7 +24,8 @@
 
 @implementation NYTScalingImageViewTests
 
-#pragma mark - Accessors
+#pragma mark - Helpers
+
 - (NSString *)gifPath {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -41,16 +42,32 @@
     return _imageData;
 }
 
-- (void)testInitializationAcceptsNil {
-    XCTAssertNoThrow([[NYTScalingImageView alloc] initWithImageData:nil frame:CGRectZero]);
+#pragma mark - Tests
+
+- (void)testImageInitializationAcceptsEmptyData {
+    XCTAssertNoThrow([[NYTScalingImageView alloc] initWithImage:[UIImage new] frame:CGRectZero]);
 }
 
-- (void)testImageViewExistsAfterInitialization {
-    NYTScalingImageView *scalingImageView = [[NYTScalingImageView alloc] initWithImageData:nil frame:CGRectZero];
+- (void)testDataInitializationAcceptsEmptyData {
+    XCTAssertNoThrow([[NYTScalingImageView alloc] initWithImageData:[NSData new] frame:CGRectZero]);
+}
+
+- (void)testImageViewExistsAfterImageInitialization {
+    NYTScalingImageView *scalingImageView = [[NYTScalingImageView alloc] initWithImage:[UIImage new] frame:CGRectZero];
     XCTAssertNotNil(scalingImageView.imageView);
 }
 
-- (void)testInitializationSetsImage {
+- (void)testImageViewExistsAfterDataInitialization {
+    NYTScalingImageView *scalingImageView = [[NYTScalingImageView alloc] initWithImageData:[NSData new] frame:CGRectZero];
+    XCTAssertNotNil(scalingImageView.imageView);
+}
+
+- (void)testImageInitializationSetsImage {
+    NYTScalingImageView *scalingImageView = [[NYTScalingImageView alloc] initWithImage:[UIImage new] frame:CGRectZero];
+    XCTAssertNotNil(scalingImageView.imageView.image);
+}
+
+- (void)testDataInitializationSetsImage {
     NYTScalingImageView *scalingImageView = [[NYTScalingImageView alloc] initWithImageData:self.imageData frame:CGRectZero];
 
 #ifdef ANIMATED_GIF_SUPPORT
@@ -61,6 +78,14 @@
 }
 
 - (void)testUpdateImageUpdatesImage {
+    UIImage *image = [UIImage new];
+    NYTScalingImageView *scalingImageView = [[NYTScalingImageView alloc] initWithImage:image frame:CGRectZero];
+    [scalingImageView updateImage:image];
+    
+    XCTAssertEqual(scalingImageView.imageView.image, image);
+}
+
+- (void)testUpdateImageDataUpdatesImage {
     NSData *image2 = [NSData dataWithContentsOfFile:self.gifPath];
     
     NYTScalingImageView *scalingImageView = [[NYTScalingImageView alloc] initWithImageData:self.imageData frame:CGRectZero];

--- a/Pod/Classes/ios/NYTPhotoViewController.m
+++ b/Pod/Classes/ios/NYTPhotoViewController.m
@@ -126,17 +126,19 @@ NSString * const NYTPhotoViewControllerPhotoImageUpdatedNotification = @"NYTPhot
 - (void)photoImageUpdatedWithNotification:(NSNotification *)notification {
     id <NYTPhoto> photo = notification.object;
     if ([photo conformsToProtocol:@protocol(NYTPhoto)] && [photo isEqual:self.photo]) {
-        if (photo.imageData) {
-            return [self updateImageData:photo.imageData];
-        }
-        [self updateImageData:UIImagePNGRepresentation(photo.image)];
+        [self updateImage:photo.image imageData:photo.imageData];
     }
 }
 
-- (void)updateImageData:(NSData *)imageData {
-    [self.scalingImageView updateImageData:imageData];
-    
+- (void)updateImage:(UIImage *)image imageData:(NSData *)imageData {
     if (imageData) {
+        [self.scalingImageView updateImageData:imageData];
+    }
+    else {
+        [self.scalingImageView updateImage:image];
+    }
+    
+    if (imageData || image) {
         [self.loadingView removeFromSuperview];
         self.loadingView = nil;
     }

--- a/Pod/Classes/ios/NYTPhotoViewController.m
+++ b/Pod/Classes/ios/NYTPhotoViewController.m
@@ -94,15 +94,20 @@ NSString * const NYTPhotoViewControllerPhotoImageUpdatedNotification = @"NYTPhot
 
 - (void)commonInitWithPhoto:(id <NYTPhoto>)photo loadingView:(UIView *)loadingView notificationCenter:(NSNotificationCenter *)notificationCenter {
     _photo = photo;
-
-    NSData *photoImage = photo.imageData ? photo.imageData : UIImagePNGRepresentation((photo.image ?: photo.placeholderImage));
-
-    _scalingImageView = [[NYTScalingImageView alloc] initWithImageData:photoImage frame:CGRectZero];
-    _scalingImageView.delegate = self;
-
-    if (!photoImage) {
-        [self setupLoadingView:loadingView];
+    
+    if (photo.imageData) {
+        _scalingImageView = [[NYTScalingImageView alloc] initWithImageData:photo.imageData frame:CGRectZero];
     }
+    else {
+        UIImage *photoImage = photo.image ?: photo.placeholderImage;
+        _scalingImageView = [[NYTScalingImageView alloc] initWithImage:photoImage frame:CGRectZero];
+        
+        if (!photoImage) {
+            [self setupLoadingView:loadingView];
+        }
+    }
+    
+    _scalingImageView.delegate = self;
 
     _notificationCenter = notificationCenter;
 

--- a/Pod/Classes/ios/NYTScalingImageView.h
+++ b/Pod/Classes/ios/NYTScalingImageView.h
@@ -31,14 +31,31 @@
  *
  *  @return A fully initialized object.
  */
-- (instancetype)initWithImageData:(NSData *)image frame:(CGRect)frame NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithImage:(UIImage *)image frame:(CGRect)frame NS_DESIGNATED_INITIALIZER;
+
+/**
+ *  Initializes a scaling image view with `NSData` representing an animated image. This object is a `UIScrollView` that contains a `UIImageView`. This allows for zooming and panning around the image.
+ *
+ *  @param imageData An `NSData` representing of an animated image for zooming and panning.
+ *  @param frame The frame of the view.
+ *
+ *  @return A fully initialized object.
+ */
+- (instancetype)initWithImageData:(NSData *)imageData frame:(CGRect)frame NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Updates the image in the image view and centers and zooms the new image.
  *
  *  @param image The new image to display in the image view.
  */
-- (void)updateImageData:(NSData *)image;
+- (void)updateImage:(UIImage *)image;
+
+/**
+ *  Updates the image in the image view and centers and zooms the new image.
+ *
+ *  @param imageData The data representing an animated image to display in the image view.
+ */
+- (void)updateImageData:(NSData *)imageData;
 
 /**
  *  Centers the image inside of the scroll view. Typically used after rotation, or when zooming has finished.

--- a/Pod/Classes/ios/NYTScalingImageView.m
+++ b/Pod/Classes/ios/NYTScalingImageView.m
@@ -37,7 +37,7 @@
     self = [super initWithCoder:aDecoder];
 
     if (self) {
-        [self commonInitWithImage:nil];
+        [self commonInitWithImage:nil imageData:nil];
     }
 
     return self;
@@ -56,52 +56,70 @@
 
 #pragma mark - NYTScalingImageView
 
-- (id)initWithImageData:(NSData *)image frame:(CGRect)frame {
+- (instancetype)initWithImage:(UIImage *)image frame:(CGRect)frame {
     self = [super initWithFrame:frame];
-    
+
     if (self) {
-        [self commonInitWithImage:image];
+        [self commonInitWithImage:image imageData:nil];
     }
     
     return self;
 }
 
-- (void)commonInitWithImage:(NSData *)image {
-    [self setupInternalImageViewWithImageData:image];
+- (instancetype)initWithImageData:(NSData *)imageData frame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    
+    if (self) {
+        [self commonInitWithImage:nil imageData:imageData];
+    }
+    
+    return self;
+}
+
+- (void)commonInitWithImage:(UIImage *)image imageData:(NSData *)imageData {
+    [self setupInternalImageViewWithImage:image imageData:imageData];
     [self setupImageScrollView];
     [self updateZoomScale];
 }
 
 #pragma mark - Setup
 
-- (void)setupInternalImageViewWithImageData:(NSData *)imageData {
-    UIImage *image = [UIImage imageWithData:imageData];
+- (void)setupInternalImageViewWithImage:(UIImage *)image imageData:(NSData *)imageData {
+    UIImage *imageToUse = image ?: [UIImage imageWithData:imageData];
 
 #ifdef ANIMATED_GIF_SUPPORT
-    self.imageView = [[FLAnimatedImageView alloc] initWithImage:image];
+    self.imageView = [[FLAnimatedImageView alloc] initWithImage:imageToUse];
 #else
-    self.imageView = [[UIImageView alloc] initWithImage:image];
+    self.imageView = [[UIImageView alloc] initWithImage:imageToUse];
 #endif
-    [self updateImageData:imageData];
+    [self updateImage:imageToUse imageData:imageData];
     
     [self addSubview:self.imageView];
 }
 
+- (void)updateImage:(UIImage *)image {
+    [self updateImage:image imageData:nil];
+}
+
 - (void)updateImageData:(NSData *)imageData {
-    UIImage *image = [UIImage imageWithData:imageData];
+    [self updateImage:nil imageData:imageData];
+}
+
+- (void)updateImage:(UIImage *)image imageData:(NSData *)imageData {
+    UIImage *imageToUse = image ?: [UIImage imageWithData:imageData];
 
     // Remove any transform currently applied by the scroll view zooming.
     self.imageView.transform = CGAffineTransformIdentity;
-    self.imageView.image = image;
+    self.imageView.image = imageToUse;
     
 #ifdef ANIMATED_GIF_SUPPORT
     // It's necessarry to first assign the UIImage so calulations for layout go right (see above)
     self.imageView.animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData];
 #endif
     
-    self.imageView.frame = CGRectMake(0, 0, image.size.width, image.size.height);
+    self.imageView.frame = CGRectMake(0, 0, imageToUse.size.width, imageToUse.size.height);
     
-    self.contentSize = image.size;
+    self.contentSize = imageToUse.size;
     
     [self updateZoomScale];
     [self centerScrollViewContents];


### PR DESCRIPTION
This pull request is a proposal to improve the public API of `NYTScalingImageView` and the internal code of both that class and `NYTPhotoViewer` to elevate using normal `UIImage`s to a first-class behavior after the addition of animated GIF support.

Currently, on develop, `NYTScalingImageView` only has APIs that support `NSData`, which means that `NYTPhoto` objects that only contain a non-animated `UIImage` are shoehorned into an API that then causes `UIImages` to be converted to data (a potentially metadata-lossy conversion) in order to call these APIs, and then _back_ to `UIImage` objects internally in those methods. This is both less performant and more complex than an API that treats `UIImage` and `NSData` equally, as they are in the `NYTPhoto` protocol. This pull request adds that API and removes the need for converting images to data and then converting that data back to images again.

Additionally, the docs for these new APIs that take `NSData` were never updated to reflect that fact, so I have also updated those in this pull request.