### PR TITLE
Removes Unused iOS 7 Workaround Method

### DIFF
--- a/Pod/Classes/ios/NYTPhotoTransitionAnimator.m
+++ b/Pod/Classes/ios/NYTPhotoTransitionAnimator.m
@@ -187,23 +187,6 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
 
 #pragma mark - Convenience
 
-- (CGAffineTransform)transformForOrientation:(UIInterfaceOrientation)orientation {
-    switch (orientation) {
-        case UIInterfaceOrientationLandscapeLeft:
-            return CGAffineTransformMakeRotation(-M_PI / 2.0);
-        
-        case UIInterfaceOrientationLandscapeRight:
-            return CGAffineTransformMakeRotation(M_PI / 2.0);
-        
-        case UIInterfaceOrientationPortraitUpsideDown:
-            return CGAffineTransformMakeRotation(M_PI);
-        
-        case UIInterfaceOrientationPortrait:
-        default:
-            return CGAffineTransformMakeRotation(0);
-    }
-}
-
 - (BOOL)shouldPerformZoomingAnimation {
     return self.startingView && self.endingView;
 }


### PR DESCRIPTION
Removes a method, which is now unused, that was created to workaround a bug on iOS 7 that is no longer relevant since the minimum version for this project is now iOS 8.