### PR TITLE
Include FLAnimatedImage version in Podspec

### DIFF
--- a/NYTPhotoViewer.podspec
+++ b/NYTPhotoViewer.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
     ss.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ANIMATED_GIF_SUPPORT=1'}
 
     ss.dependency 'NYTPhotoViewer/Core'
-    ss.dependency 'FLAnimatedImage'
+    ss.dependency 'FLAnimatedImage', '~> 1.0.8'
   end
 
 end


### PR DESCRIPTION
The podspec _should_ have included a specific version for FLAnimatedImage. This change specifies that `~> 1.0.8` should be used, since that's the version [currently installed in the Example project](https://github.com/NYTimes/NYTPhotoViewer/blob/develop/Example/Podfile.lock#L2).