### PR TITLE
Fix orientation issue with reference view of type UIImageView

### DIFF
--- a/Pod/Classes/ios/NYTPhotoTransitionAnimator.m
+++ b/Pod/Classes/ios/NYTPhotoTransitionAnimator.m
@@ -227,19 +227,28 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
     
     UIView *animationView;
     
-    if (view.layer.contents) {
-        animationView = [[UIView alloc] initWithFrame:view.frame];
-        animationView.layer.contents = view.layer.contents;
-        animationView.layer.bounds = view.layer.bounds;
-        animationView.layer.cornerRadius = view.layer.cornerRadius;
-        animationView.layer.masksToBounds = view.layer.masksToBounds;
-        animationView.contentMode = view.contentMode;
-        animationView.transform = view.transform;
-    }
-    else {
-        animationView = [view snapshotViewAfterScreenUpdates:YES];
-    }
-    
+	if (view.layer.contents) {
+		if ([view isKindOfClass:[UIImageView class]]) {
+			// The case of UIImageView is handled separately since the mere layer's contents (i.e. CGImage in this case) doesn't
+			// seem to contain proper informations about the image orientation for portrait images taken directly on the device.
+			animationView = [(UIImageView *)[[view class] alloc] initWithImage:((UIImageView *)view).image];
+			animationView.bounds = view.bounds;
+		}
+		else {
+			animationView = [[UIView alloc] initWithFrame:view.frame];
+			animationView.layer.contents = view.layer.contents;
+			animationView.layer.bounds = view.layer.bounds;
+		}
+
+		animationView.layer.cornerRadius = view.layer.cornerRadius;
+		animationView.layer.masksToBounds = view.layer.masksToBounds;
+		animationView.contentMode = view.contentMode;
+		animationView.transform = view.transform;
+	}
+	else {
+		animationView = [view snapshotViewAfterScreenUpdates:YES];
+	}
+
     return animationView;
 }
 


### PR DESCRIPTION
The issue occurred during in and out animations when the reference
view is a UIImageView containing a UIImage with meaningful
orientation informations (e.g. taken directly with the device in
portrait orientation). See #115.