### PR TITLE
[Feature] Top caption view for overlay view

### DIFF
--- a/Example/NYTPhotoViewer-Swift/Base.lproj/Main.storyboard
+++ b/Example/NYTPhotoViewer-Swift/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14D113c" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
     </dependencies>
     <scenes>

--- a/Example/NYTPhotoViewer-Swift/ViewController.swift
+++ b/Example/NYTPhotoViewer-Swift/ViewController.swift
@@ -94,6 +94,17 @@ class ViewController: UIViewController, NYTPhotosViewControllerDelegate {
         return nil
     }
     
+    func photosViewController(photosViewController: NYTPhotosViewController, topCaptionViewForPhoto photo: NYTPhoto) -> UIView? {
+        if photo as! ExamplePhoto == photos[CustomEverythingPhotoIndex] {
+            let label = UILabel()
+            label.text = "Custom Top Caption View"
+            label.textColor = UIColor.whiteColor()
+            label.backgroundColor = UIColor.greenColor()
+            return label
+        }
+        return nil
+    }
+    
     func photosViewController(photosViewController: NYTPhotosViewController, didNavigateToPhoto photo: NYTPhoto, atIndex photoIndex: UInt) {
         print("Did Navigate To Photo: \(photo) identifier: \(photoIndex)")
     }

--- a/Example/NYTPhotoViewer/NYTViewController.m
+++ b/Example/NYTPhotoViewer/NYTViewController.m
@@ -140,6 +140,19 @@ typedef NS_ENUM(NSUInteger, NYTViewControllerPhotoIndex) {
     return nil;
 }
 
+-(UIView *)photosViewController:(NYTPhotosViewController *)photosViewController topCaptionViewForPhoto:(id<NYTPhoto>)photo
+{
+    if ([photo isEqual:self.photos[NYTViewControllerPhotoIndexCustomEverything]]) {
+        UILabel *label = [[UILabel alloc] init];
+        label.text = @"Custom Top Caption View";
+        label.textColor = [UIColor whiteColor];
+        label.backgroundColor = [UIColor greenColor];
+        return label;
+    }
+    
+    return nil;
+}
+
 - (CGFloat)photosViewController:(NYTPhotosViewController *)photosViewController maximumZoomScaleForPhoto:(id <NYTPhoto>)photo {
     if ([photo isEqual:self.photos[NYTViewControllerPhotoIndexCustomMaxZoomScale]]) {
         return 10.0f;

--- a/Pod/Classes/ios/NYTPhotosOverlayView.h
+++ b/Pod/Classes/ios/NYTPhotosOverlayView.h
@@ -51,9 +51,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSArray <UIBarButtonItem *> *rightBarButtonItems;
 
 /**
+ *  A view representing the top caption for the photo, which will be set to full width and locked to the top, under navigation bar. Can be any `UIView` object, but is expected to respond to `intrinsicContentSize` appropriately to calculate height.
+ */
+@property (nonatomic, nullable) UIView *topCaptionView;
+
+/**
  *  A view representing the caption for the photo, which will be set to full width and locked to the bottom. Can be any `UIView` object, but is expected to respond to `intrinsicContentSize` appropriately to calculate height.
  */
-@property (nonatomic, nullable) UIView *captionView;
+@property (nonatomic, nonnull) UIView *captionView;
 
 @end
 

--- a/Pod/Classes/ios/NYTPhotosOverlayView.m
+++ b/Pod/Classes/ios/NYTPhotosOverlayView.m
@@ -80,13 +80,33 @@
     [self addConstraints:@[topConstraint, widthConstraint, horizontalPositionConstraint]];
 }
 
+- (void)setTopCaptionView:(UIView *)topCaptionView {
+    if (self.topCaptionView == topCaptionView) {
+        return;
+    }
+    
+    [self.topCaptionView removeFromSuperview];
+    _topCaptionView = topCaptionView;
+    
+    if (self.topCaptionView == nil) {
+        return;
+    }
+    
+    self.topCaptionView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:self.topCaptionView];
+    
+    NSLayoutConstraint *topConstraint = [NSLayoutConstraint constraintWithItem:self.navigationBar attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self.topCaptionView attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0];
+    NSLayoutConstraint *widthConstraint = [NSLayoutConstraint constraintWithItem:self.topCaptionView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeWidth multiplier:1.0 constant:0.0];
+    NSLayoutConstraint *horizontalPositionConstraint = [NSLayoutConstraint constraintWithItem:self.topCaptionView attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0.0];
+    [self addConstraints:@[topConstraint, widthConstraint, horizontalPositionConstraint]];
+}
+
 - (void)setCaptionView:(UIView *)captionView {
     if (self.captionView == captionView) {
         return;
     }
     
     [self.captionView removeFromSuperview];
-    
     _captionView = captionView;
     
     self.captionView.translatesAutoresizingMaskIntoConstraints = NO;

--- a/Pod/Classes/ios/NYTPhotosViewController.h
+++ b/Pod/Classes/ios/NYTPhotosViewController.h
@@ -149,6 +149,16 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 - (UIView * _Nullable)photosViewController:(NYTPhotosViewController *)photosViewController captionViewForPhoto:(id <NYTPhoto>)photo;
 
 /**
+ *  Returns a view to display over a photo, full width, locked to the top, under navigation bar, representing the top caption for the photo. Can be any `UIView` object, but is expected to respond to `intrinsicContentSize` appropriately to calculate height.
+ *
+ *  @param photosViewController The `NYTPhotosViewController` instance that sent the delegate message.
+ *  @param photo                The photo object over which to display the caption view.
+ *
+ *  @return A view to display as the top caption for the photo. Return `nil` to show nothing.
+ */
+- (UIView * _Nullable)photosViewController:(NYTPhotosViewController *)photosViewController topCaptionViewForPhoto:(id<NYTPhoto>)photo;
+
+/**
  *  Returns a view to display while a photo is loading. Can be any `UIView` object, but is expected to respond to `sizeToFit` appropriately. This view will be sized and centered in the blank area, and hidden when the photo image is loaded.
  *
  *  @param photosViewController The `NYTPhotosViewController` instance that sent the delegate message.

--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -234,11 +234,16 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     if ([self.delegate respondsToSelector:@selector(photosViewController:captionViewForPhoto:)]) {
         captionView = [self.delegate photosViewController:self captionViewForPhoto:self.currentlyDisplayedPhoto];
     }
+    UIView * topCaptionView;
+    if ([self.delegate respondsToSelector:@selector(photosViewController:topCaptionViewForPhoto:)]) {
+        topCaptionView = [self.delegate photosViewController:self topCaptionViewForPhoto:self.currentlyDisplayedPhoto];
+    }
     
     if (!captionView) {
         captionView = [[NYTPhotoCaptionView alloc] initWithAttributedTitle:self.currentlyDisplayedPhoto.attributedCaptionTitle attributedSummary:self.currentlyDisplayedPhoto.attributedCaptionSummary attributedCredit:self.currentlyDisplayedPhoto.attributedCaptionCredit];
     }
     
+    self.overlayView.topCaptionView = topCaptionView;
     self.overlayView.captionView = captionView;
 }
 


### PR DESCRIPTION
Hey!

Thanks for awesome library, like it a lot! In my project I stumbled across design, that requires caption views not only on bottom but on top as well.

This PR adds ability to return top caption view using delegate callbacks similar to caption view on the bottom.

The only difference is when you return nil from top caption view method, no view is displayed.

I've also updated Swift and Objective-C examples with usage of top caption view(see custom caption screen)