### PR TITLE
Followup from dismissal PR #121

### DIFF
--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -375,6 +375,10 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
             
             [[NSNotificationCenter defaultCenter] postNotificationName:NYTPhotosViewControllerDidDismissNotification object:self];
         }
+
+        if (completion) {
+            completion();
+        }
     }];
 }
 

--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -354,8 +354,12 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     
     self.transitionController.startingView = startingView;
     self.transitionController.endingView = self.referenceViewForCurrentPhoto;
+
+    // Cocoa convention is not to call delegate methods when you do something directly in code,
+    // so we'll not call delegate methods if this is a programmatic, noninteractive dismissal:
+    BOOL shouldSendDelegateMessages = self.transitionController.forcesNonInteractiveDismissal;
     
-    if ([self.delegate respondsToSelector:@selector(photosViewControllerWillDismiss:)]) {
+    if (shouldSendDelegateMessages && [self.delegate respondsToSelector:@selector(photosViewControllerWillDismiss:)]) {
         [self.delegate photosViewControllerWillDismiss:self];
     }
     
@@ -369,7 +373,7 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
         }
         
         if (!isStillOnscreen) {
-            if ([self.delegate respondsToSelector:@selector(photosViewControllerDidDismiss:)]) {
+            if (shouldSendDelegateMessages && [self.delegate respondsToSelector:@selector(photosViewControllerDidDismiss:)]) {
                 [self.delegate photosViewControllerDidDismiss:self];
             }
             

--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -336,8 +336,6 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
 - (void)didPanWithGestureRecognizer:(UIPanGestureRecognizer *)panGestureRecognizer {
     if (panGestureRecognizer.state == UIGestureRecognizerStateBegan) {
         self.transitionController.forcesNonInteractiveDismissal = NO;
-        self.overlayWasHiddenBeforeTransition = self.overlayView.hidden;
-        [self setOverlayViewHidden:YES animated:YES];
         [self dismissViewControllerAnimated:YES completion:nil];
     }
     else {
@@ -354,6 +352,9 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     
     self.transitionController.startingView = startingView;
     self.transitionController.endingView = self.referenceViewForCurrentPhoto;
+
+    self.overlayWasHiddenBeforeTransition = self.overlayView.hidden;
+    [self setOverlayViewHidden:YES animated:animated];
 
     // Cocoa convention is not to call delegate methods when you do something directly in code,
     // so we'll not call delegate methods if this is a programmatic, noninteractive dismissal:

--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -346,7 +346,7 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     }
 }
     
-- (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion {
+- (void)dismissViewControllerAnimated:(BOOL)animated completion:(void (^)(void))completion {
     UIView *startingView;
     if (self.currentlyDisplayedPhoto.image || self.currentlyDisplayedPhoto.placeholderImage || self.currentlyDisplayedPhoto.imageData) {
         startingView = self.currentPhotoViewController.scalingImageView.imageView;
@@ -361,7 +361,7 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     
     [[NSNotificationCenter defaultCenter] postNotificationName:NYTPhotosViewControllerWillDismissNotification object:self];
     
-    [super dismissViewControllerAnimated:flag completion:^{
+    [super dismissViewControllerAnimated:animated completion:^{
         BOOL isStillOnscreen = self.view.window != nil; // Happens when the dismissal is canceled.
         
         if (isStillOnscreen && !self.overlayWasHiddenBeforeTransition) {

--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -346,8 +346,7 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     }
 }
     
--(void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion
-{
+- (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion {
     UIView *startingView;
     if (self.currentlyDisplayedPhoto.image || self.currentlyDisplayedPhoto.placeholderImage || self.currentlyDisplayedPhoto.imageData) {
         startingView = self.currentPhotoViewController.scalingImageView.imageView;


### PR DESCRIPTION
I've done some minor cleanup and fixed a few minor bugs from the (merged) dismissal fix in #121:

- The completion block supplied to `dismissViewControllerAnimated:…` is no longer ignored: https://github.com/NYTimes/NYTPhotoViewer/commit/79d35948aa950556b01e2a5d830521e884be5113
- Overlay view management on dismissal is now handled in one place for all styles of dismissal: https://github.com/NYTimes/NYTPhotoViewer/commit/c17b7f7e27f231ca4187dba77f3a831f082faa5e
- In keeping with Cocoa convention, delegate methods aren't called for programmatic dismissals: https://github.com/NYTimes/NYTPhotoViewer/commit/e5b3144dd869c61aa7a977587a6d69eb21de8546
- Plus minor naming & code style fixes.