### PR TITLE
Use bundleForClass on a NYTPhotoViewer class to retrieve the appropriate bundle

### DIFF
--- a/Pod/Classes/ios/Resource Loading/NSBundle+NYTPhotoViewer.m
+++ b/Pod/Classes/ios/Resource Loading/NSBundle+NYTPhotoViewer.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSBundle+NYTPhotoViewer.h"
+#import "NYTPhotosViewController.h"
 
 @implementation NSBundle (NYTPhotoViewer)
 
@@ -14,7 +15,7 @@
     static NSBundle *resourceBundle = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSString *resourceBundlePath = [[NSBundle mainBundle] pathForResource:@"NYTPhotoViewer" ofType:@"bundle"];
+        NSString *resourceBundlePath = [[NSBundle bundleForClass:[NYTPhotosViewController class]] pathForResource:@"NYTPhotoViewer" ofType:@"bundle"];
         resourceBundle = [self bundleWithPath:resourceBundlePath];
     });
     return resourceBundle;


### PR DESCRIPTION
(Recreated #114 in a fresh PR) 

In a final attempt to continue using bundles through cocoapods, hopefully this will fix any outstanding issues people are having with getting the close button image.

(Hopefully) Fixes #102