### PR TITLE
Fix delegate calls on interactive dismissal transitions

### DIFF
--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -358,7 +358,7 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
 
     // Cocoa convention is not to call delegate methods when you do something directly in code,
     // so we'll not call delegate methods if this is a programmatic, noninteractive dismissal:
-    BOOL shouldSendDelegateMessages = self.transitionController.forcesNonInteractiveDismissal;
+    BOOL shouldSendDelegateMessages = !self.transitionController.forcesNonInteractiveDismissal;
     
     if (shouldSendDelegateMessages && [self.delegate respondsToSelector:@selector(photosViewControllerWillDismiss:)]) {
         [self.delegate photosViewControllerWillDismiss:self];


### PR DESCRIPTION
closes #129

This was a stupid reversed-logic bug. I even tried extracting this to a boolean to keep the logic straight, but something with the "forces non interactive" naming messed with my head, I guess.