### PR TITLE
Send delegate messages for all user-initiated dismissals

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -12,8 +12,3 @@ end
 target 'NYTPhotoViewer-Swift', :exclusive => true do
     pod "NYTPhotoViewer/AnimatedGifSupport", :path => "../"
 end
-
-target 'NYTPhotoViewer-SwiftTests', :exclusive => true do
-    pod "NYTPhotoViewer/AnimatedGifSupport", :path => "../"
-    pod 'OCMock', '~> 3.2'
-end

--- a/Example/Tests/NYTPhotosOverlayViewTests.m
+++ b/Example/Tests/NYTPhotosOverlayViewTests.m
@@ -12,7 +12,6 @@
 #import <NYTPhotoViewer/NYTPhotosOverlayView.h>
 
 @interface NYTPhotosOverlayViewTests : XCTestCase
-
 @end
 
 @implementation NYTPhotosOverlayViewTests

--- a/Example/Tests/NYTPhotosViewControllerTests.m
+++ b/Example/Tests/NYTPhotosViewControllerTests.m
@@ -231,6 +231,7 @@
     [photosViewController doneButtonTapped:nil];
 
     OCMVerifyAll(photosVCMock);
+    [photosVCMock stopMocking];
 }
 
 - (void)testGestureBasedDismissalUserInitiatedFlagIsTrue {
@@ -246,6 +247,7 @@
     [photosViewController didPanWithGestureRecognizer:gestureRecognizerMock];
 
     OCMVerifyAll(photosVCMock);
+    [photosVCMock stopMocking];
 }
 
 - (void)testProgrammaticDismissalUserInitiatedFlagIsFalse {
@@ -258,6 +260,7 @@
     [photosViewController dismissViewControllerAnimated:YES completion:nil];
 
     OCMVerifyAll(photosVCMock);
+    [photosVCMock stopMocking];
 }
 
 #pragma mark - Helpers

--- a/Example/Tests/NYTPhotosViewControllerTests.m
+++ b/Example/Tests/NYTPhotosViewControllerTests.m
@@ -226,11 +226,10 @@
     NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:photos];
 
     id photosVCMock = OCMPartialMock(photosViewController);
-    OCMExpect([photosVCMock dismissViewControllerAnimated:YES userInitiated:YES completion:[OCMArg isNil]]);
 
     [photosViewController doneButtonTapped:nil];
 
-    OCMVerifyAll(photosVCMock);
+    OCMVerify([photosVCMock dismissViewControllerAnimated:YES userInitiated:YES completion:[OCMArg any]]);
 }
 
 - (void)testGestureBasedDismissalUserInitiatedFlagIsTrue {
@@ -238,14 +237,13 @@
     NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:photos];
 
     id photosVCMock = OCMPartialMock(photosViewController);
-    OCMExpect([photosVCMock dismissViewControllerAnimated:YES userInitiated:YES completion:[OCMArg isNil]]);
 
     id gestureRecognizerMock = OCMClassMock([UIPanGestureRecognizer class]);
     OCMStub([gestureRecognizerMock state]).andReturn(UIGestureRecognizerStateBegan);
 
     [photosViewController didPanWithGestureRecognizer:gestureRecognizerMock];
 
-    OCMVerifyAll(photosVCMock);
+    OCMVerify([photosVCMock dismissViewControllerAnimated:YES userInitiated:YES completion:[OCMArg any]]);
 }
 
 - (void)testProgrammaticDismissalUserInitiatedFlagIsFalse {
@@ -253,11 +251,10 @@
     NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:photos];
 
     id photosVCMock = OCMPartialMock(photosViewController);
-    OCMExpect([photosVCMock dismissViewControllerAnimated:YES userInitiated:NO completion:[OCMArg isNil]]);
 
     [photosViewController dismissViewControllerAnimated:YES completion:nil];
 
-    OCMVerifyAll(photosVCMock);
+    OCMVerify([photosVCMock dismissViewControllerAnimated:YES userInitiated:NO completion:[OCMArg any]]);
 }
 
 #pragma mark - Helpers

--- a/Example/Tests/NYTPhotosViewControllerTests.m
+++ b/Example/Tests/NYTPhotosViewControllerTests.m
@@ -9,10 +9,20 @@
 @import UIKit;
 @import XCTest;
 
+#import <OCMock/OCMock.h>
+
 #import <NYTPhotoViewer/NYTPhotosViewController.h>
 #import "NYTExamplePhoto.h"
 
 @interface NYTPhotosViewControllerTests : XCTestCase
+@end
+
+@interface NYTPhotosViewController (Testing)
+
+- (void)dismissViewControllerAnimated:(BOOL)animated userInitiated:(BOOL)isUserInitiated completion:(void (^)(void))completion;
+- (void)didPanWithGestureRecognizer:(UIPanGestureRecognizer *)panGestureRecognizer;
+- (void)doneButtonTapped:(id)sender;
+
 @end
 
 @implementation NYTPhotosViewControllerTests
@@ -209,6 +219,45 @@
     NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:photos];
 
     XCTAssertFalse(photosViewController.pageViewController.isViewLoaded);
+}
+
+- (void)testDoneButtonDismissalUserInitiatedFlagIsTrue {
+    NSArray *photos = [self newTestPhotos];
+    NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:photos];
+
+    id photosVCMock = OCMPartialMock(photosViewController);
+    OCMExpect([photosVCMock dismissViewControllerAnimated:[OCMArg isEqual:OCMOCK_VALUE(YES)] userInitiated:[OCMArg isEqual:OCMOCK_VALUE(YES)] completion:[OCMArg isNil]]);
+
+    [photosViewController doneButtonTapped:nil];
+
+    OCMVerifyAll(photosVCMock);
+}
+
+- (void)testGestureBasedDismissalUserInitiatedFlagIsTrue {
+    NSArray *photos = [self newTestPhotos];
+    NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:photos];
+
+    id photosVCMock = OCMPartialMock(photosViewController);
+    OCMExpect([photosVCMock dismissViewControllerAnimated:[OCMArg isEqual:OCMOCK_VALUE(YES)] userInitiated:[OCMArg isEqual:OCMOCK_VALUE(YES)] completion:[OCMArg isNil]]);
+
+    id gestureRecognizerMock = OCMClassMock([UIPanGestureRecognizer class]);
+    OCMStub([gestureRecognizerMock state]).andReturn(UIGestureRecognizerStateBegan);
+
+    [photosViewController didPanWithGestureRecognizer:gestureRecognizerMock];
+
+    OCMVerifyAll(photosVCMock);
+}
+
+- (void)testProgrammaticDismissalUserInitiatedFlagIsFalse {
+    NSArray *photos = [self newTestPhotos];
+    NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:photos];
+
+    id photosVCMock = OCMPartialMock(photosViewController);
+    OCMExpect([photosVCMock dismissViewControllerAnimated:[OCMArg isEqual:OCMOCK_VALUE(YES)] userInitiated:[OCMArg isEqual:OCMOCK_VALUE(NO)] completion:[OCMArg isNil]]);
+
+    [photosViewController dismissViewControllerAnimated:YES completion:nil];
+
+    OCMVerifyAll(photosVCMock);
 }
 
 #pragma mark - Helpers

--- a/Example/Tests/NYTPhotosViewControllerTests.m
+++ b/Example/Tests/NYTPhotosViewControllerTests.m
@@ -226,12 +226,11 @@
     NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:photos];
 
     id photosVCMock = OCMPartialMock(photosViewController);
-    OCMExpect([photosVCMock dismissViewControllerAnimated:[OCMArg isEqual:OCMOCK_VALUE(YES)] userInitiated:[OCMArg isEqual:OCMOCK_VALUE(YES)] completion:[OCMArg isNil]]);
+    OCMExpect([photosVCMock dismissViewControllerAnimated:YES userInitiated:YES completion:[OCMArg isNil]]);
 
     [photosViewController doneButtonTapped:nil];
 
     OCMVerifyAll(photosVCMock);
-    [photosVCMock stopMocking];
 }
 
 - (void)testGestureBasedDismissalUserInitiatedFlagIsTrue {
@@ -239,7 +238,7 @@
     NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:photos];
 
     id photosVCMock = OCMPartialMock(photosViewController);
-    OCMExpect([photosVCMock dismissViewControllerAnimated:[OCMArg isEqual:OCMOCK_VALUE(YES)] userInitiated:[OCMArg isEqual:OCMOCK_VALUE(YES)] completion:[OCMArg isNil]]);
+    OCMExpect([photosVCMock dismissViewControllerAnimated:YES userInitiated:YES completion:[OCMArg isNil]]);
 
     id gestureRecognizerMock = OCMClassMock([UIPanGestureRecognizer class]);
     OCMStub([gestureRecognizerMock state]).andReturn(UIGestureRecognizerStateBegan);
@@ -247,7 +246,6 @@
     [photosViewController didPanWithGestureRecognizer:gestureRecognizerMock];
 
     OCMVerifyAll(photosVCMock);
-    [photosVCMock stopMocking];
 }
 
 - (void)testProgrammaticDismissalUserInitiatedFlagIsFalse {
@@ -255,12 +253,11 @@
     NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:photos];
 
     id photosVCMock = OCMPartialMock(photosViewController);
-    OCMExpect([photosVCMock dismissViewControllerAnimated:[OCMArg isEqual:OCMOCK_VALUE(YES)] userInitiated:[OCMArg isEqual:OCMOCK_VALUE(NO)] completion:[OCMArg isNil]]);
+    OCMExpect([photosVCMock dismissViewControllerAnimated:YES userInitiated:NO completion:[OCMArg isNil]]);
 
     [photosViewController dismissViewControllerAnimated:YES completion:nil];
 
     OCMVerifyAll(photosVCMock);
-    [photosVCMock stopMocking];
 }
 
 #pragma mark - Helpers

--- a/Example/Tests/NYTPhotosViewControllerTests.m
+++ b/Example/Tests/NYTPhotosViewControllerTests.m
@@ -13,7 +13,6 @@
 #import "NYTExamplePhoto.h"
 
 @interface NYTPhotosViewControllerTests : XCTestCase
-
 @end
 
 @implementation NYTPhotosViewControllerTests

--- a/Pod/Classes/ios/NYTPhotosViewController.h
+++ b/Pod/Classes/ios/NYTPhotosViewController.h
@@ -15,7 +15,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// All notifications will have the `NYTPhotosViewController` instance set as the object.
+/**
+ *  Notification name issued when this `NYTPhotosViewController` navigates to a different photo.
+ *
+ *  Includes the `NYTPhotosViewController` instance, as the notification's object.
+ */
 extern NSString * const NYTPhotosViewControllerDidNavigateToPhotoNotification;
 
 /**

--- a/Pod/Classes/ios/NYTPhotosViewController.h
+++ b/Pod/Classes/ios/NYTPhotosViewController.h
@@ -17,7 +17,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 // All notifications will have the `NYTPhotosViewController` instance set as the object.
 extern NSString * const NYTPhotosViewControllerDidNavigateToPhotoNotification;
+
+/**
+ *  Notification name issued when this `NYTPhotosViewController` is about to be dismissed.
+ *
+ *  Includes the `NYTPhotosViewController` instance, as the notification's object.
+ */
 extern NSString * const NYTPhotosViewControllerWillDismissNotification;
+
+/**
+ *  Notification name issued when this `NYTPhotosViewController` has been dismissed.
+ *
+ *  Includes the `NYTPhotosViewController` instance, as the notification's object.
+ */
 extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 
 @interface NYTPhotosViewController : UIViewController
@@ -125,14 +137,15 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 - (void)photosViewController:(NYTPhotosViewController *)photosViewController didNavigateToPhoto:(id <NYTPhoto>)photo atIndex:(NSUInteger)photoIndex;
 
 /**
- *  Called immediately before the photos view controller is about to start dismissal. This will be the beginning of the interactive panning to dismiss, if it is enabled and performed.
+ *  Called immediately before the `NYTPhotosViewController` is about to start a user-initiated dismissal.
+ *  This will be the beginning of the interactive panning to dismiss, if it is enabled and performed.
  *
  *  @param photosViewController The `NYTPhotosViewController` instance that sent the delegate message.
  */
 - (void)photosViewControllerWillDismiss:(NYTPhotosViewController *)photosViewController;
 
 /**
- *  Called immediately after the photos view controller has dismissed.
+ *  Called immediately after the photos view controller has been dismissed by the user.
  *
  *  @param photosViewController The `NYTPhotosViewController` instance that sent the delegate message.
  */

--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -354,6 +354,8 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
         [self.transitionController didPanWithPanGestureRecognizer:panGestureRecognizer viewToPan:self.pageViewController.view anchorPoint:self.boundsCenterPoint];
     }
 }
+
+#pragma mark - View Controller Dismissal
     
 - (void)dismissViewControllerAnimated:(BOOL)animated completion:(void (^)(void))completion {
     UIView *startingView;


### PR DESCRIPTION
- Refactor how dismissals are managed, to allow disambiguating user-initiated and programmatic dismissals for determination of whether to send delegate messages, without tracking an additional bit of state.
- https://github.com/NYTimes/NYTPhotoViewer/commit/16bd3c040b69bd5b2b125d1b8f15d1bb03e272ba should've been covered in #128 , but I just now noticed it
- Other commits in this PR are documentation improvements around this behavior, and minor style improvements.

Closes #134.