### PR TITLE
Documentation and clarification around NYTPhoto.image vs .imageData

### DIFF
--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -264,11 +264,8 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     if ([self.delegate respondsToSelector:@selector(photosViewController:handleActionButtonTappedForPhoto:)]) {
         clientDidHandle = [self.delegate photosViewController:self handleActionButtonTappedForPhoto:self.currentlyDisplayedPhoto];
     }
-#ifdef ANIMATED_GIF_SUPPORT
+    
     if (!clientDidHandle && (self.currentlyDisplayedPhoto.image || self.currentlyDisplayedPhoto.imageData)) {
-#else
-    if (!clientDidHandle && self.currentlyDisplayedPhoto.image) {
-#endif
         UIImage *image = self.currentlyDisplayedPhoto.image ? self.currentlyDisplayedPhoto.image : [UIImage imageWithData:self.currentlyDisplayedPhoto.imageData];
         UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:@[image] applicationActivities:nil];
         activityViewController.popoverPresentationController.barButtonItem = sender;

--- a/Pod/Classes/ios/NYTScalingImageView.m
+++ b/Pod/Classes/ios/NYTScalingImageView.m
@@ -106,6 +106,14 @@
 }
 
 - (void)updateImage:(UIImage *)image imageData:(NSData *)imageData {
+#ifdef DEBUG
+#ifndef ANIMATED_GIF_SUPPORT
+    if (imageData != nil) {
+        NSLog(@"[NYTPhotoViewer] Warning! You're providing imageData for a photo, but NYTPhotoViewer was compiled without animated GIF support. You should use native UIImages for non-animated photos. See the NYTPhoto protocol documentation for discussion.");
+    }
+#endif // ANIMATED_GIF_SUPPORT
+#endif // DEBUG
+
     UIImage *imageToUse = image ?: [UIImage imageWithData:imageData];
 
     // Remove any transform currently applied by the scroll view zooming.

--- a/Pod/Classes/ios/Protocols/NYTPhoto.h
+++ b/Pod/Classes/ios/Protocols/NYTPhoto.h
@@ -17,17 +17,24 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  The image to display.
+ *
+ *  This property is used if and only if `-imageData` returns `nil`, but note that using `UIImage`s whenever possible will result in better performance. See `-imageData`'s documentation for discussion.
  */
 @property (nonatomic, readonly, nullable) UIImage *image;
 
 /**
- * The image data to display. This will be preferred over the `image` property.
- * In case this is empty `image` will be used. The main advantage of using this is animated gif support.
+ *  The image data to display.
+ *  
+ *  This property's value is preferred over `-image`, if `imageData` is non-`nil`. This allows clients to provide image data for FLAnimatedImage when the library is compiled with `ANIMATED_GIF_SUPPORT` defined.
+ *
+ *  Note that if you're working with a non-animated image, using a native `UIImage` will provide better performance. Therefore, it is recommended to return `nil` from this property unless this photo is an animated GIF.
  */
 @property (nonatomic, readonly, nullable) NSData *imageData;
 
 /**
  *  A placeholder image for display while the image is loading.
+ *
+ *  This property is used if and only if `-imageData` returns `nil`.
  */
 @property (nonatomic, readonly, nullable) UIImage *placeholderImage;
 

--- a/Pod/Classes/ios/Protocols/NYTPhoto.h
+++ b/Pod/Classes/ios/Protocols/NYTPhoto.h
@@ -18,14 +18,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  The image to display.
  *
- *  This property is used if and only if `-imageData` returns `nil`, but note that using `UIImage`s whenever possible will result in better performance. See `-imageData`'s documentation for discussion.
+ *  This property is used if and only if `-imageData` returns `nil`. Note, however, that returning `UIImage`s from this property whenever possible will result in better performance. See `-imageData`'s documentation for discussion.
  */
 @property (nonatomic, readonly, nullable) UIImage *image;
 
 /**
  *  The image data to display.
  *  
- *  This property's value is preferred over `-image`, if `imageData` is non-`nil`. This allows clients to provide image data for FLAnimatedImage when the library is compiled with `ANIMATED_GIF_SUPPORT` defined.
+ *  This property's value, if non-`nil`, is preferred over `-image`. This allows clients to provide image data for FLAnimatedImage when the library is compiled with `ANIMATED_GIF_SUPPORT` defined.
  *
  *  Note that if you're working with a non-animated image, using a native `UIImage` will provide better performance. Therefore, it is recommended to return `nil` from this property unless this photo is an animated GIF.
  */


### PR DESCRIPTION
This is mostly followup from the changes in #106.

- https://github.com/NYTimes/NYTPhotoViewer/commit/8ece787e3b0f26c70ee8ab5208d8f846f0cb0b6b cleans up one place where we could've seen inconsistent behavior in builds without animated GIF support (see commit message for details)
- https://github.com/NYTimes/NYTPhotoViewer/commit/043299bbb94dbb3340c5ea13ced805b5875d220d is a documentation improvement in `NYTPhoto` about `image` vs `imageData`
- https://github.com/NYTimes/NYTPhotoViewer/commit/34f45a198f4b8b3d4952798f65c71c4056f941a5 adds a warning log message (in debug builds only) when you use the `imageData` property but animated GIF support is compiled out (since that really makes no sense, as discussed in #106)