### PR TITLE
Add `delegate` to the designated initializer

### DIFF
--- a/Example/Tests/NYTPhotosViewControllerTests.m
+++ b/Example/Tests/NYTPhotosViewControllerTests.m
@@ -136,20 +136,46 @@
     XCTAssertNil(photosViewController.rightBarButtonItems);
 }
 
-- (void)testConvenienceInitializerAcceptsNil {
+- (void)testOneArgConvenienceInitializerAcceptsNil {
     XCTAssertNoThrow([[NYTPhotosViewController alloc] initWithPhotos:nil]);
 }
 
-- (void)testDesignatedInitializerAcceptsNilForPhotosParameter {
+- (void)testTwoArgConvenienceInitializerAcceptsNilForPhotosParameter {
     XCTAssertNoThrow([[NYTPhotosViewController alloc] initWithPhotos:nil initialPhoto:[[NYTExamplePhoto alloc] init]]);
 }
 
-- (void)testDesignatedInitializerAcceptsNilForInitialPhotoParameter {
+- (void)testTwoArgConvenienceInitializerAcceptsNilForInitialPhotoParameter {
     XCTAssertNoThrow([[NYTPhotosViewController alloc] initWithPhotos:[self newTestPhotos] initialPhoto:nil]);
 }
 
-- (void)testDesignatedInitializerAcceptsNilForBothParameters {
+- (void)testTwoArgConvenienceInitializerAcceptsNilForBothParameters {
     XCTAssertNoThrow([[NYTPhotosViewController alloc] initWithPhotos:nil initialPhoto:nil]);
+}
+
+- (void)testDesignatedInitializerAcceptsNilForPhotosParameter {
+    id delegateMock = OCMProtocolMock(@protocol(NYTPhotosViewControllerDelegate));
+    XCTAssertNoThrow([[NYTPhotosViewController alloc] initWithPhotos:nil initialPhoto:[NYTExamplePhoto new] delegate:delegateMock]);
+
+}
+
+- (void)testDesignatedInitializerAcceptsNilForInitialPhotoParameter {
+    id delegateMock = OCMProtocolMock(@protocol(NYTPhotosViewControllerDelegate));
+    XCTAssertNoThrow([[NYTPhotosViewController alloc] initWithPhotos:[self newTestPhotos] initialPhoto:nil delegate:delegateMock]);
+}
+
+- (void)testDesignatedInitializerAcceptsNilForDelegateParameter {
+    XCTAssertNoThrow([[NYTPhotosViewController alloc] initWithPhotos:[self newTestPhotos] initialPhoto:[NYTExamplePhoto new] delegate:nil]);
+}
+
+- (void)testDesignatedInitializerAcceptsNilForAllParameters {
+    XCTAssertNoThrow([[NYTPhotosViewController alloc] initWithPhotos:nil initialPhoto:nil delegate:nil]);
+}
+
+- (void)testDesignatedInitializerSetsDelegate {
+    id delegateMock = OCMProtocolMock(@protocol(NYTPhotosViewControllerDelegate));
+    NYTPhotosViewController *sut = [[NYTPhotosViewController alloc] initWithPhotos:[self newTestPhotos] initialPhoto:nil delegate:delegateMock];
+
+    XCTAssertEqual(sut.delegate, delegateMock);
 }
 
 - (void)testDisplayPhotoAcceptsNil {

--- a/Example/Tests/NYTPhotosViewControllerTests.m
+++ b/Example/Tests/NYTPhotosViewControllerTests.m
@@ -155,7 +155,6 @@
 - (void)testDesignatedInitializerAcceptsNilForPhotosParameter {
     id delegateMock = OCMProtocolMock(@protocol(NYTPhotosViewControllerDelegate));
     XCTAssertNoThrow([[NYTPhotosViewController alloc] initWithPhotos:nil initialPhoto:[NYTExamplePhoto new] delegate:delegateMock]);
-
 }
 
 - (void)testDesignatedInitializerAcceptsNilForInitialPhotoParameter {

--- a/Pod/Classes/ios/NYTPhotosViewController.h
+++ b/Pod/Classes/ios/NYTPhotosViewController.h
@@ -89,7 +89,7 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 @property (nonatomic, weak, nullable) id <NYTPhotosViewControllerDelegate> delegate;
 
 /**
- *  A convenience initializer that calls `initWithPhotos:initialPhoto:`, passing the first photo as the `initialPhoto` argument.
+ *  A convenience initializer that calls `initWithPhotos:initialPhoto:delegate:`, passing the first photo as the `initialPhoto` argument, and `nil` as the `delegate` argument.
  *
  *  @param photos An array of objects conforming to the `NYTPhoto` protocol.
  *
@@ -98,14 +98,25 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 - (instancetype)initWithPhotos:(NSArray <id <NYTPhoto>> * _Nullable)photos;
 
 /**
- *  The designated initializer that stores the array of objects conforming to the `NYTPhoto` protocol for display, along with specifying an initial photo for display.
+ *  A convenience initializer that calls `initWithPhotos:initialPhoto:delegate:`, passing `nil` as the `delegate` argument.
  *
  *  @param photos An array of objects conforming to the `NYTPhoto` protocol.
  *  @param initialPhoto The photo to display initially. Must be contained within the `photos` array. If `nil` or not within the `photos` array, the first photo within the `photos` array will be displayed.
  *
  *  @return A fully initialized object.
  */
-- (instancetype)initWithPhotos:(NSArray <id <NYTPhoto>> * _Nullable)photos initialPhoto:(id <NYTPhoto> _Nullable)initialPhoto NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithPhotos:(NSArray <id <NYTPhoto>> * _Nullable)photos initialPhoto:(id <NYTPhoto> _Nullable)initialPhoto;
+
+/**
+ *  The designated initializer that stores the array of objects conforming to the `NYTPhoto` protocol for display, along with specifying an initial photo for display.
+ *
+ *  @param photos An array of objects conforming to the `NYTPhoto` protocol.
+ *  @param initialPhoto The photo to display initially. Must be contained within the `photos` array. If `nil` or not within the `photos` array, the first photo within the `photos` array will be displayed.
+ *  @param delegate The delegate for this `NYTPhotosViewController`.
+ *
+ *  @return A fully initialized object.
+ */
+- (instancetype)initWithPhotos:(NSArray <id <NYTPhoto>> * _Nullable)photos initialPhoto:(id <NYTPhoto> _Nullable)initialPhoto delegate:(nullable id <NYTPhotosViewControllerDelegate>)delegate NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Displays the specified photo. Can be called before the view controller is displayed. Calling with a photo not contained within the data source has no effect.

--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -94,7 +94,7 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     self = [super initWithCoder:aDecoder];
 
     if (self) {
-        [self commonInitWithPhotos:nil initialPhoto:nil];
+        [self commonInitWithPhotos:nil initialPhoto:nil delegate:nil];
     }
 
     return self;
@@ -156,21 +156,27 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
 #pragma mark - NYTPhotosViewController
 
 - (instancetype)initWithPhotos:(NSArray *)photos {
-    return [self initWithPhotos:photos initialPhoto:photos.firstObject];
+    return [self initWithPhotos:photos initialPhoto:photos.firstObject delegate:nil];
 }
 
 - (instancetype)initWithPhotos:(NSArray *)photos initialPhoto:(id <NYTPhoto>)initialPhoto {
+    return [self initWithPhotos:photos initialPhoto:initialPhoto delegate:nil];
+}
+
+- (instancetype)initWithPhotos:(NSArray *)photos initialPhoto:(id <NYTPhoto>)initialPhoto delegate:(id<NYTPhotosViewControllerDelegate>)delegate {
     self = [super initWithNibName:nil bundle:nil];
     
     if (self) {
-        [self commonInitWithPhotos:photos initialPhoto:initialPhoto];
+        [self commonInitWithPhotos:photos initialPhoto:initialPhoto delegate:delegate];
     }
     
     return self;
 }
 
-- (void)commonInitWithPhotos:(NSArray *)photos initialPhoto:(id <NYTPhoto>)initialPhoto {
+- (void)commonInitWithPhotos:(NSArray *)photos initialPhoto:(id <NYTPhoto>)initialPhoto delegate:(id<NYTPhotosViewControllerDelegate>)delegate {
     _dataSource = [[NYTPhotosDataSource alloc] initWithPhotos:photos];
+    _delegate = delegate;
+
     _panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(didPanWithGestureRecognizer:)];
     _singleTapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didSingleTapWithGestureRecognizer:)];
 


### PR DESCRIPTION
closes #95.

The previous designated initializer remains as a convenience initializer, making this API change non-breaking, and allowing this to be released as a new minor version.