### PR TITLE
Avoid gradient flickering of caption view on iOS 9

### DIFF
--- a/Pod/Classes/ios/NYTPhotoCaptionView.m
+++ b/Pod/Classes/ios/NYTPhotoCaptionView.m
@@ -58,11 +58,14 @@ static const CGFloat NYTPhotoCaptionViewVerticalMargin = 7.0;
 - (void)layoutSubviews {
     [super layoutSubviews];
 
+    void (^updateGradientFrame)() = ^{
+        self.gradientLayer.frame = self.layer.bounds;
+    };
+    
+    updateGradientFrame();
     // On iOS 8.x, when this view is height-constrained, neither `self.bounds` nor `self.layer.bounds` reflects the new layout height immediately after `[super layoutSubviews]`. Both of those properties appear correct in the next runloop.
     // This problem doesn't affect iOS 9 and there may be a better solution; PRs welcome.
-    dispatch_async(dispatch_get_main_queue(), ^{
-        self.gradientLayer.frame = self.layer.bounds;
-    });
+    dispatch_async(dispatch_get_main_queue(), updateGradientFrame);
 }
 
 - (CGSize)intrinsicContentSize {


### PR DESCRIPTION
Update gradientLayer frame in current runloop is needed, or you'll see the flicker (due to CALayer's implicit animation).