### PR TITLE
Fix gradient flickering of caption view on iOS 9

### DIFF
--- a/NYTPhotoViewer/NYTPhotoCaptionView.m
+++ b/NYTPhotoViewer/NYTPhotoCaptionView.m
@@ -58,11 +58,15 @@ static const CGFloat NYTPhotoCaptionViewVerticalMargin = 7.0;
 - (void)layoutSubviews {
     [super layoutSubviews];
 
+    void (^updateGradientFrame)() = ^{
+        self.gradientLayer.frame = self.layer.bounds;
+    };
+
+    updateGradientFrame();
+
     // On iOS 8.x, when this view is height-constrained, neither `self.bounds` nor `self.layer.bounds` reflects the new layout height immediately after `[super layoutSubviews]`. Both of those properties appear correct in the next runloop.
     // This problem doesn't affect iOS 9 and there may be a better solution; PRs welcome.
-    dispatch_async(dispatch_get_main_queue(), ^{
-        self.gradientLayer.frame = self.layer.bounds;
-    });
+    dispatch_async(dispatch_get_main_queue(), updateGradientFrame);
 }
 
 - (CGSize)intrinsicContentSize {


### PR DESCRIPTION
This implements @cxa's fix from https://github.com/NYTimes/NYTPhotoViewer/pull/165 on top of the large project restructuring from https://github.com/NYTimes/NYTPhotoViewer/pull/164 .

I've reproduced the issue and verfied this fix on an iOS 9 device.