### PR TITLE
Include all files in the bundle, not just PNGs, in Cocoapods resource bundle

### DIFF
--- a/NYTPhotoViewer.podspec
+++ b/NYTPhotoViewer.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.subspec 'Core' do |ss|
-    ss.ios.resource_bundle = { s.name => ['NYTPhotoViewer/NYTPhotoViewer.bundle/*.png'] }
+    ss.ios.resource_bundle = { s.name => ['NYTPhotoViewer/NYTPhotoViewer.bundle/*'] }
     ss.source_files = 'NYTPhotoViewer/**/*.{h,m,swift}'
     ss.frameworks = 'UIKit', 'Foundation'
   end


### PR DESCRIPTION
This change has no functional effect at this time. However, now that we have a proper bundle in the repo, it seems proper to direct CocoaPods to package _all_ files in that bundle into its (equivalent) resource bundle.

This eliminates room for future error: if a non-PNG file is added to the bundle, before this change, it would appear to work with Carthage but not with CocoaPods.