### PR TITLE
Remove `ANIMATED_GIF_SUPPORT` preprocessor conditionals from unit tests

### DIFF
--- a/NYTPhotoViewerTests/NYTScalingImageViewTests.m
+++ b/NYTPhotoViewerTests/NYTScalingImageViewTests.m
@@ -10,10 +10,7 @@
 @import XCTest;
 
 #import <NYTPhotoViewer/NYTScalingImageView.h>
-
-#ifdef ANIMATED_GIF_SUPPORT
 #import <FLAnimatedImage/FLAnimatedImage.h>
-#endif
 
 @interface NYTScalingImageViewTests : XCTestCase
 
@@ -70,11 +67,7 @@
 - (void)testDataInitializationSetsImage {
     NYTScalingImageView *scalingImageView = [[NYTScalingImageView alloc] initWithImageData:self.imageData frame:CGRectZero];
 
-#ifdef ANIMATED_GIF_SUPPORT
-    XCTAssertEqual(self.imageData, scalingImageView.imageView.animatedImage.data);
-#else
-    XCTAssertNotNil(scalingImageView.imageView.image);
-#endif
+    XCTAssertEqual(self.imageData, ((FLAnimatedImageView *)scalingImageView.imageView).animatedImage.data);
 }
 
 - (void)testUpdateImageUpdatesImage {
@@ -90,21 +83,14 @@
     
     NYTScalingImageView *scalingImageView = [[NYTScalingImageView alloc] initWithImageData:self.imageData frame:CGRectZero];
     [scalingImageView updateImageData:image2];
-    
-#ifdef ANIMATED_GIF_SUPPORT
-    XCTAssertEqual(image2, scalingImageView.imageView.animatedImage.data);
-#else
-    XCTAssertNotNil(scalingImageView.imageView.image);
-#endif
+
+    XCTAssertEqual(image2, ((FLAnimatedImageView *)scalingImageView.imageView).animatedImage.data);
 }
 
 - (void)testImageViewIsOfCorrectKindAfterInitialization {
     NYTScalingImageView *scalingImageViewer = [[NYTScalingImageView alloc] initWithImageData:self.imageData frame:CGRectZero];
-#ifdef ANIMATED_GIF_SUPPORT
+
     XCTAssertTrue([scalingImageViewer.imageView isKindOfClass:FLAnimatedImageView.class]);
-#else
-    XCTAssertTrue([scalingImageViewer.imageView isKindOfClass:UIImageView.class]);
-#endif
 }
 
 @end


### PR DESCRIPTION
When we added Carthage support ( https://github.com/NYTimes/NYTPhotoViewer/pull/164 ), we created two NYTPhotoViewer targets: the “normal” one which includes animated gif support (via `ANIMATED_GIF_SUPPORT=1`, and requires linking with FLAnimatedImage); and the “-Core” target which does not include animated GIF support.

_For brevity I will refer to the library target with animated gif support as “-Normal” even though it doesn’t have that suffix (the “-Core” target _does_ have that suffix)._

The unit tests are configured to run against the “-Normal” target, but they weren’t compiled with `ANIMATED_GIF_SUPPORT=1`, so we were running unit tests intended for “-Core” against the “-Normal” target. This resulted in some test failures.

I’ve fixed them by removing the `ANIMATED_GIF_SUPPORT` conditionals from the test target, leaving in the code that should be run against “-Normal”.

I am unsure whether it’s worth making a new “-Core” test target just to include the three assertions (removed in this commit) which were intended to apply to “-Core”. Feedback is welcome.