### PR TITLE
Fix the final transform, if the reference view is part of a scrollView hierarchy

### DIFF
--- a/NYTPhotoViewer/NYTPhotoCaptionView.m
+++ b/NYTPhotoViewer/NYTPhotoCaptionView.m
@@ -114,6 +114,7 @@ static const CGFloat NYTPhotoCaptionViewVerticalMargin = 7.0;
     self.textView = [[UITextView alloc] initWithFrame:CGRectZero textContainer:nil];
     self.textView.translatesAutoresizingMaskIntoConstraints = NO;
     self.textView.editable = NO;
+    self.textView.selectable = NO;
     self.textView.dataDetectorTypes = UIDataDetectorTypeNone;
     self.textView.backgroundColor = [UIColor clearColor];
     self.textView.textContainerInset = UIEdgeInsetsMake(NYTPhotoCaptionViewVerticalMargin, NYTPhotoCaptionViewHorizontalMargin, NYTPhotoCaptionViewVerticalMargin, NYTPhotoCaptionViewHorizontalMargin);

--- a/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
+++ b/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
@@ -126,10 +126,16 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
         finalEndingViewTransform = CGAffineTransformConcat(finalEndingViewTransform, transformedView.transform);
     }
 
+    CGAffineTransform startingViewTransform = self.startingView.transform;
+    for (UIView *transformedView = self.startingView.superview; transformedView != nil; transformedView = transformedView.superview) {
+        startingViewTransform = CGAffineTransformConcat(startingViewTransform, transformedView.transform);
+    }
+    startingViewForAnimation.transform = startingViewTransform;
+
     CGFloat endingViewInitialTransform = CGRectGetHeight(startingViewForAnimation.frame) / CGRectGetHeight(endingViewForAnimation.frame);
     CGPoint translatedStartingViewCenter = [[self class] centerPointForView:self.startingView
                                                   translatedToContainerView:containerView];
-    
+
     startingViewForAnimation.center = translatedStartingViewCenter;
     
     endingViewForAnimation.transform = CGAffineTransformScale(endingViewForAnimation.transform, endingViewInitialTransform, endingViewInitialTransform);

--- a/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
+++ b/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
@@ -122,6 +122,9 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
     }
     
     CGAffineTransform finalEndingViewTransform = self.endingView.transform;
+    for (UIView *transformedView = self.endingView.superview; transformedView != nil; transformedView = transformedView.superview) {
+        finalEndingViewTransform = CGAffineTransformConcat(finalEndingViewTransform, transformedView.transform);
+    }
 
     CGFloat endingViewInitialTransform = CGRectGetHeight(startingViewForAnimation.frame) / CGRectGetHeight(endingViewForAnimation.frame);
     CGPoint translatedStartingViewCenter = [[self class] centerPointForView:self.startingView


### PR DESCRIPTION
This fixes an incorrect computation of `finalEndingViewTransform`, if the reference view is part of a `UIScrollView` hierarchy (but not the contentView of the scrollView). In this case the `transform` of the reference view is (normally) set to `CGAffineTransformIdentity`, even though the enclosing scrollView is zoomed.
# Changes proposed in this PR
- Walk the view hierarchy to correctly compute the final transform of the reference view
# Tests performed
- Dismissal when the reference view is part of a scrollView-hierarchy
- Dismissal when the reference view is not part of a scrollView-hierarchy
