### PR TITLE
Fix issue 39

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dSYM
 *.xcuserstate
 project.xcworkspace/
 xcuserdata/
+DerivedData
 
 # Generated files
 *.o

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -103,10 +103,6 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    self.view.tintColor = [UIColor whiteColor];
-    self.view.backgroundColor = [UIColor blackColor];
-    self.pageViewController.view.backgroundColor = [UIColor clearColor];
-
     [self.pageViewController.view addGestureRecognizer:self.panGestureRecognizer];
     [self.pageViewController.view addGestureRecognizer:self.singleTapGestureRecognizer];
     
@@ -124,6 +120,13 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     }
     
     self.transitionController.endingView = endingView;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    self.view.tintColor = [UIColor whiteColor];
+    self.view.backgroundColor = [UIColor blackColor];
+    self.pageViewController.view.backgroundColor = [UIColor clearColor];
 }
 
 - (void)viewDidAppear:(BOOL)animated {


### PR DESCRIPTION
This commit fixes an issue where backgroundColor and tintColor values are not properly being reset after dismissal of view controller. This also adds DerivedData to .gitignore to prevent local env from making its way in to github.

Fixes issue #39.