### PR TITLE
Readd loading view when photo source is set back to nil.

### DIFF
--- a/NYTPhotoViewer/NYTPhotoViewController.m
+++ b/NYTPhotoViewer/NYTPhotoViewController.m
@@ -140,7 +140,8 @@ NSString * const NYTPhotoViewControllerPhotoImageUpdatedNotification = @"NYTPhot
     
     if (imageData || image) {
         [self.loadingView removeFromSuperview];
-        self.loadingView = nil;
+    } else {
+        [self.view addSubview:self.loadingView];
     }
 }
 


### PR DESCRIPTION
This commit prevents the destruction of loading view and adds it back as a subview when the image and imageData is empty.

Fixes issue #186.