### PR TITLE
Added titleTextAttributes property for customizing overlayView title

### DIFF
--- a/Example/NYTViewController.m
+++ b/Example/NYTViewController.m
@@ -34,6 +34,7 @@ typedef NS_ENUM(NSUInteger, NYTViewControllerPhotoIndex) {
     
     NYTPhotosViewController *photosViewController = [[NYTPhotosViewController alloc] initWithPhotos:self.photos];
     photosViewController.delegate = self;
+    photosViewController.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor whiteColor], NSFontAttributeName : [UIFont fontWithName:@"Arial" size:20.0]};
     [self presentViewController:photosViewController animated:YES completion:nil];
     
     [self updateImagesOnPhotosViewController:photosViewController afterDelayWithPhotos:self.photos];

--- a/NYTPhotoViewer/NYTPhotosViewController.h
+++ b/NYTPhotoViewer/NYTPhotosViewController.h
@@ -64,6 +64,11 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 @property (nonatomic, readonly, nullable) NYTPhotosOverlayView *overlayView;
 
 /**
+ *  Set custom title attributes of overlayView.
+ */
+@property (nonatomic, copy, nullable)NSDictionary <NSString *, id> *titleTextAttributes;
+
+/**
  *  The left bar button item overlaying the photo.
  */
 @property (nonatomic, nullable) UIBarButtonItem *leftBarButtonItem;

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -217,7 +217,8 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     NSAssert(self.overlayView != nil, @"_overlayView must be set during initialization, to provide bar button items for this %@", NSStringFromClass([self class]));
 
     UIColor *textColor = self.view.tintColor ?: [UIColor whiteColor];
-    self.overlayView.titleTextAttributes = @{NSForegroundColorAttributeName: textColor};
+
+    self.overlayView.titleTextAttributes = (self.titleTextAttributes)?self.titleTextAttributes:@{NSForegroundColorAttributeName: textColor};
     
     [self updateOverlayInformation];
     [self.view addSubview:self.overlayView];
@@ -293,6 +294,10 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
         controller.popoverPresentationController.barButtonItem = self.rightBarButtonItem;
         [self presentViewController:controller animated:animated completion:nil];
     }
+}
+
+-(void)setTitleTextAttributes:(NSDictionary<NSString *,id> *)titleTextAttributes{
+    _titleTextAttributes = titleTextAttributes;
 }
 
 - (UIBarButtonItem *)leftBarButtonItem {


### PR DESCRIPTION
Easily customize the controller title instead of using delegate (photosViewController:overlayTitleTextAttributesForPhoto) which I for whatever reason can't make it work right now.