### PR TITLE
Bump to version 1.2.0

### DIFF
--- a/NYTPhotoViewer.podspec
+++ b/NYTPhotoViewer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "NYTPhotoViewer"
-  s.version          = "1.1.0"
+  s.version          = "1.2.0"
 
   s.description      = <<-DESC
                        NYTPhotoViewer is a slideshow and image viewer that includes double tap to zoom, captions, support for multiple images, interactive flick to dismiss, animated zooming presentation, and more.

--- a/NYTPhotoViewer/Info.plist
+++ b/NYTPhotoViewer/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Cutting a new release will at least bring Carthage support to users on `master`.