### PR TITLE
reset the dismissing view's backgroundColor's alpha to 1.0 after pan-to-dismiss

### DIFF
--- a/NYTPhotoViewer/NYTPhotoDismissalInteractionController.m
+++ b/NYTPhotoViewer/NYTPhotoDismissalInteractionController.m
@@ -94,6 +94,7 @@ static const CGFloat NYTPhotoDismissalInteractionControllerReturnToCenterVelocit
                 }
             }
             
+            fromView.backgroundColor = [fromView.backgroundColor colorWithAlphaComponent:1.0];
             self.viewToHideWhenBeginningTransition.alpha = 1.0;
             
             [self.transitionContext completeTransition:isDismissing && !self.transitionContext.transitionWasCancelled];


### PR DESCRIPTION
When dismissing a photos vc, the dismissal interaction sets the background alpha to 0.0, so if you have a photo viewer cached, and want to present it multiple times, the background alpha will be set to 0.0 on the second, third, …th presentation.

(to reproduce:
1. have a vc with photo models and a `NYTPhotosViewController` property
2. present the photos vc to show a photo
3. let someone flick-to-dismiss the photo
4. present another photo using the same photos vc

the background of the photos vc is missing after it finishes presenting due to step 4)

I'm not positive if this is the _best_ way to fix the bug -- someone could have a background color with an alpha of something other than 1.0 set, but there's existing code in the same method that also seems to assume we're targeting an alpha of 1.0, so, this seemed like a safe place to start the discussion.
