### PR TITLE
Move content under statusBar if prefersStatusBarHidden is false

### DIFF
--- a/NYTPhotoViewer/NYTPhotosViewController.h
+++ b/NYTPhotoViewer/NYTPhotosViewController.h
@@ -150,6 +150,21 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 @optional
 
 /**
+ *  Called when the view is about to made visible.
+ *
+ *  @param photosViewController The `NYTPhotosViewController` instance that sent the delegate message.
+ *  @param animated
+ */
+- (void)photosViewController:(NYTPhotosViewController *)photosViewController viewWillAppear:(BOOL)animated;
+
+/**
+ *  Called when the view is dismissed, covered or otherwise hidden.
+ *
+ *  @param photosViewController The `NYTPhotosViewController` instance that sent the delegate message.
+ */
+- (void)photosViewController:(NYTPhotosViewController *)photosViewController viewWillDisappear:(BOOL)animated;
+
+/**
  *  Called when a new photo is displayed through a swipe gesture.
  *
  *  @param photosViewController The `NYTPhotosViewController` instance that sent the delegate message.

--- a/NYTPhotoViewer/NYTPhotosViewController.h
+++ b/NYTPhotoViewer/NYTPhotosViewController.h
@@ -64,6 +64,11 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 @property (nonatomic, readonly, nullable) NYTPhotosOverlayView *overlayView;
 
 /**
+ *  Shows all content under status bar frame. Default NO.
+ */
+@property (nonatomic) BOOL underStatusBar;
+    
+/**
  *  The left bar button item overlaying the photo.
  */
 @property (nonatomic, nullable) UIBarButtonItem *leftBarButtonItem;

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -126,6 +126,20 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     self.transitionController.endingView = endingView;
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    if ([_delegate respondsToSelector:@selector(photosViewController:viewWillAppear:)]) {
+        [_delegate photosViewController:self viewWillAppear:animated];
+    }
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    if ([_delegate respondsToSelector:@selector(photosViewController:viewWillDisappear:)]) {
+        [_delegate photosViewController:self viewWillDisappear:animated];
+    }
+}
+
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -137,8 +137,14 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
 - (void)viewWillLayoutSubviews {
     [super viewWillLayoutSubviews];
     
-    self.pageViewController.view.frame = self.view.bounds;
-    self.overlayView.frame = self.view.bounds;
+    CGRect frame = self.view.bounds;
+    if (self.underStatusBar) {
+        CGFloat statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;;
+        frame.origin.y = statusBarHeight;
+        frame.size.height -= statusBarHeight;
+    }
+    self.pageViewController.view.frame = frame;
+    self.overlayView.frame = frame;
 }
 
 - (BOOL)prefersStatusBarHidden {


### PR DESCRIPTION
Allow developers to show the status bar with navigation bar buttons without overlaps.
If gallery is showed with visible status bar the navigation buttons overlaps it, with this small change you can set to move content origin under status bar to prevent it.

Before:
![captura de pantalla 2016-11-24 a las 15 50 47](https://cloud.githubusercontent.com/assets/5858119/20602747/e8461e28-b25e-11e6-95f5-fdd788c49e09.png)


After:
![captura de pantalla 2016-11-24 a las 15 49 44](https://cloud.githubusercontent.com/assets/5858119/20602741/dfa70e76-b25e-11e6-9d5b-1f910f3fd791.png)

Code:
```swift
private class PhotosViewController: NYTPhotosViewController {
    override var prefersStatusBarHidden: Bool {
        return false
    }
    
    override var preferredStatusBarStyle: UIStatusBarStyle {
        return .lightContent
    }
}

let viewer = PhotosViewController(photos: [photo], initialPhoto: photo, delegate: nil)
viewer.underStatusBar = true
self.present(viewer, animated: true, completion: nil)
```
