### PR TITLE
Fix: Parent's `viewWillAppear` etc. methods are not getting called

### DIFF
--- a/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
+++ b/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
@@ -18,6 +18,8 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
 @interface NYTPhotoTransitionAnimator ()
 
 @property (nonatomic, readonly) BOOL shouldPerformZoomingAnimation;
+@property (nonatomic, weak) UIViewController *toViewController;
+@property (nonatomic, weak) UIViewController *fromViewController;
 
 @end
 
@@ -46,8 +48,12 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
     UIView *fromView = [transitionContext viewForKey:UITransitionContextFromViewKey];
     UIView *toView = [transitionContext viewForKey:UITransitionContextToViewKey];
 
-    UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
-    toView.frame = [transitionContext finalFrameForViewController:toViewController];
+    self.toViewController =  [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+    self.fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+    
+    toView.frame = [transitionContext finalFrameForViewController:self.toViewController];
+    [self.toViewController beginAppearanceTransition:YES animated:YES];
+    [self.fromViewController beginAppearanceTransition:NO animated:YES];
     
     if (![toView isDescendantOfView:transitionContext.containerView]) {
         [transitionContext.containerView addSubview:toView];
@@ -253,6 +259,10 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
 }
 
 #pragma mark - UIViewControllerAnimatedTransitioning
+- (void)animationEnded:(BOOL)transitionCompleted {
+    [self.toViewController endAppearanceTransition];
+    [self.fromViewController endAppearanceTransition];
+}
 
 - (NSTimeInterval)transitionDuration:(id <UIViewControllerContextTransitioning>)transitionContext {
     if (self.shouldPerformZoomingAnimation) {


### PR DESCRIPTION
When presenting/dismissing `NYTPhotosViewController` the actual presenter's `viewWillAppear`, `viewDidAppear`, `viewWillDisappear` and `viewDidDisappear` methods aren't getting called. This sucks a bit.

The bug is due to the transition animator `NYTPhotoTransitionAnimator` not dispatching `beginAppearanceTransition` and `endAppearanceTransition` calls to the respective ViewControllers.

This PR fixes this.

More background info: http://stackoverflow.com/a/29041911