### PR TITLE
Bugfixes: bounds checks, don't retain data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Changes for users of the library currently on `develop`:
 
 - Expose a data-source-oriented API for PhotosViewController ([#226](https://github.com/NYTimes/NYTPhotoViewer/pull/226))
+    - A data source no longer has to handle out-of-bounds indexes ([#227](https://github.com/NYTimes/NYTPhotoViewer/pull/227))
+    - The data source is not retained ([#227](https://github.com/NYTimes/NYTPhotoViewer/pull/227))
 
 ## [1.2.0](https://github.com/NYTimes/NYTPhotoViewer/releases/tag/1.2.0)
 

--- a/NYTPhotoViewer/NYTPhotosViewController.h
+++ b/NYTPhotoViewer/NYTPhotosViewController.h
@@ -58,10 +58,8 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
  *  The data source underlying this PhotosViewController.
  *
  *  After setting a new data source, you must call `-reloadPhotosAnimated:`.
- *
- *  The data source is retained (unlike UITableView's data source).
  */
-@property (nonatomic) id <NYTPhotoViewerDataSource> dataSource;
+@property (nonatomic, weak, nullable) id <NYTPhotoViewerDataSource> dataSource;
 
 /**
  *  The object conforming to `NYTPhoto` that is currently being displayed by the `pageViewController`.

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -561,11 +561,19 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
 
 - (UIViewController *)pageViewController:(UIPageViewController *)pageViewController viewControllerBeforeViewController:(UIViewController <NYTPhotoContainer> *)viewController {
     NSUInteger photoIndex = [self.dataSource indexOfPhoto:viewController.photo];
+    if (photoIndex == 0 || photoIndex == NSNotFound) {
+        return nil;
+    }
+
     return [self newPhotoViewControllerForPhoto:[self.dataSource photoAtIndex:(photoIndex - 1)]];
 }
 
 - (UIViewController *)pageViewController:(UIPageViewController *)pageViewController viewControllerAfterViewController:(UIViewController <NYTPhotoContainer> *)viewController {
     NSUInteger photoIndex = [self.dataSource indexOfPhoto:viewController.photo];
+    if (photoIndex == NSNotFound) {
+        return nil;
+    }
+
     return [self newPhotoViewControllerForPhoto:[self.dataSource photoAtIndex:(photoIndex + 1)]];
 }
 


### PR DESCRIPTION
This fixes two bugs I found while rewriting the Swift example (#223):

* The `PhotosViewController` should not retain its data source. This will lead trivially easily to retain cycles which would be difficult to manage.
* The `PhotosViewController` was asking its data source for nonsensical bounds when scrolling from the first photo. I've added a check to avoid that, and while I was there I added a check to prevent the viewer from skipping back to the first photo when the data source returns `NSNotFound` for a photo.