### PR TITLE
Respect Safe Area Layout Guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes for users of the library currently on `develop`:
 - Expose a data-source-oriented API for PhotosViewController ([#226](https://github.com/NYTimes/NYTPhotoViewer/pull/226))
     - A data source no longer has to handle out-of-bounds indexes ([#227](https://github.com/NYTimes/NYTPhotoViewer/pull/227))
     - The data source is not retained ([#227](https://github.com/NYTimes/NYTPhotoViewer/pull/227))
+- Respect safe areas for iOS 11 support
 
 ## [1.2.0](https://github.com/NYTimes/NYTPhotoViewer/releases/tag/1.2.0)
 

--- a/NYTPhotoViewer/NYTPhotoViewController.m
+++ b/NYTPhotoViewer/NYTPhotoViewController.m
@@ -80,6 +80,10 @@ NSString * const NYTPhotoViewControllerPhotoImageUpdatedNotification = @"NYTPhot
     self.loadingView.center = CGPointMake(CGRectGetMidX(self.view.bounds), CGRectGetMidY(self.view.bounds));
 }
 
+- (BOOL)prefersHomeIndicatorAutoHidden {
+    return YES;
+}
+
 #pragma mark - NYTPhotoViewController
 
 - (instancetype)initWithPhoto:(id <NYTPhoto>)photo loadingView:(UIView *)loadingView notificationCenter:(NSNotificationCenter *)notificationCenter {

--- a/NYTPhotoViewer/NYTPhotosOverlayView.h
+++ b/NYTPhotoViewer/NYTPhotosOverlayView.h
@@ -55,6 +55,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, nullable) UIView *captionView;
 
+/**
+ *  Whether the `captionView` should respect the safe area or not
+ */
+@property (nonatomic) BOOL captionViewRespectsSafeArea;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/NYTPhotoViewer/NYTPhotosOverlayView.m
+++ b/NYTPhotoViewer/NYTPhotosOverlayView.m
@@ -9,6 +9,12 @@
 #import "NYTPhotosOverlayView.h"
 #import "NYTPhotoCaptionViewLayoutWidthHinting.h"
 
+@interface UIView (NYTSafeArea)
+
+@property (nonatomic, readonly, strong) UILayoutGuide *safeAreaLayoutGuide;
+
+@end
+
 @interface NYTPhotosOverlayView ()
 
 @property (nonatomic) UINavigationItem *navigationItem;
@@ -74,10 +80,17 @@
     
     [self addSubview:self.navigationBar];
     
-    NSLayoutConstraint *topConstraint = [NSLayoutConstraint constraintWithItem:self.navigationBar attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0];
-    NSLayoutConstraint *widthConstraint = [NSLayoutConstraint constraintWithItem:self.navigationBar attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeWidth multiplier:1.0 constant:0.0];
-    NSLayoutConstraint *horizontalPositionConstraint = [NSLayoutConstraint constraintWithItem:self.navigationBar attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0.0];
-    [self addConstraints:@[topConstraint, widthConstraint, horizontalPositionConstraint]];
+    if ([self respondsToSelector:@selector(safeAreaLayoutGuide)]) {
+        NSLayoutConstraint *topConstraint = [self.navigationBar.topAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.topAnchor];
+        NSLayoutConstraint *leftConstraint = [self.navigationBar.leftAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.leftAnchor];
+        NSLayoutConstraint *rightConstraint = [self.navigationBar.rightAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.rightAnchor];
+        [self addConstraints:@[topConstraint, leftConstraint, rightConstraint]];
+    } else {
+        NSLayoutConstraint *topConstraint = [NSLayoutConstraint constraintWithItem:self.navigationBar attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0];
+        NSLayoutConstraint *widthConstraint = [NSLayoutConstraint constraintWithItem:self.navigationBar attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeWidth multiplier:1.0 constant:0.0];
+        NSLayoutConstraint *horizontalPositionConstraint = [NSLayoutConstraint constraintWithItem:self.navigationBar attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0.0];
+        [self addConstraints:@[topConstraint, widthConstraint, horizontalPositionConstraint]];
+    }
 }
 
 - (void)setCaptionView:(UIView *)captionView {
@@ -91,11 +104,18 @@
     
     self.captionView.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:self.captionView];
-    
-    NSLayoutConstraint *bottomConstraint = [NSLayoutConstraint constraintWithItem:self.captionView attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0];
-    NSLayoutConstraint *widthConstraint = [NSLayoutConstraint constraintWithItem:self.captionView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeWidth multiplier:1.0 constant:0.0];
-    NSLayoutConstraint *horizontalPositionConstraint = [NSLayoutConstraint constraintWithItem:self.captionView attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0.0];
-    [self addConstraints:@[bottomConstraint, widthConstraint, horizontalPositionConstraint]];
+
+    if ([self respondsToSelector:@selector(safeAreaLayoutGuide)] && self.captionViewRespectsSafeArea) {
+        NSLayoutConstraint *bottomConstraint = [self.captionView.bottomAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.bottomAnchor];
+        NSLayoutConstraint *leftConstraint = [self.captionView.leftAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.leftAnchor];
+        NSLayoutConstraint *rightConstraint = [self.captionView.rightAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.rightAnchor];
+        [self addConstraints:@[bottomConstraint, leftConstraint, rightConstraint]];
+    } else {
+        NSLayoutConstraint *bottomConstraint = [NSLayoutConstraint constraintWithItem:self.captionView attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0];
+        NSLayoutConstraint *widthConstraint = [NSLayoutConstraint constraintWithItem:self.captionView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeWidth multiplier:1.0 constant:0.0];
+        NSLayoutConstraint *horizontalPositionConstraint = [NSLayoutConstraint constraintWithItem:self.captionView attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0.0];
+        [self addConstraints:@[bottomConstraint, widthConstraint, horizontalPositionConstraint]];
+    }
 }
 
 - (UIBarButtonItem *)leftBarButtonItem {

--- a/NYTPhotoViewer/NYTPhotosViewController.h
+++ b/NYTPhotoViewer/NYTPhotosViewController.h
@@ -216,6 +216,8 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 /**
  *  Returns whether the caption view should respect the safe area.
  *
+ * @note If this method is not implemented it will default to `YES`.
+ *
  *  @param photosViewController The `NYTPhotosViewController` instance that sent the delegate message.
  *  @param photo                The photo object over which to display the caption view.
  *

--- a/NYTPhotoViewer/NYTPhotosViewController.h
+++ b/NYTPhotoViewer/NYTPhotosViewController.h
@@ -214,6 +214,16 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
 - (UIView * _Nullable)photosViewController:(NYTPhotosViewController *)photosViewController captionViewForPhoto:(id <NYTPhoto>)photo;
 
 /**
+ *  Returns whether the caption view should respect the safe area.
+ *
+ *  @param photosViewController The `NYTPhotosViewController` instance that sent the delegate message.
+ *  @param photo                The photo object over which to display the caption view.
+ *
+ *  @return A `BOOL` indicating whether the caption view should respect the safe area for the given photo or not.
+ */
+- (BOOL)photosViewController:(NYTPhotosViewController *)photosViewController captionViewRespectsSafeAreaForPhoto:(id <NYTPhoto>)photo;
+
+/**
  *  Returns a string to display as the title in the navigation-bar area for a photo.
  *
  *  This small area of the screen is not intended to display a caption or similar information about the photo itself. (NYTPhotoViewer is designed to provide this information in the caption view, and as such the `NYTPhoto` protocol provides properties for a title, summary, and credit for each photo.) Instead, consider using this delegate method to customize how your app displays the user's progress through a set of photos.

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -260,7 +260,13 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     if (!captionView) {
         captionView = [[NYTPhotoCaptionView alloc] initWithAttributedTitle:self.currentlyDisplayedPhoto.attributedCaptionTitle attributedSummary:self.currentlyDisplayedPhoto.attributedCaptionSummary attributedCredit:self.currentlyDisplayedPhoto.attributedCaptionCredit];
     }
-    
+
+    BOOL captionViewRespectsSafeArea = YES;
+    if ([self.delegate respondsToSelector:@selector(photosViewController:captionViewRespectsSafeAreaForPhoto:)]) {
+        captionViewRespectsSafeArea = [self.delegate photosViewController:self captionViewRespectsSafeAreaForPhoto:self.currentlyDisplayedPhoto];
+    }
+
+    self.overlayView.captionViewRespectsSafeArea = captionViewRespectsSafeArea;
     self.overlayView.captionView = captionView;
 }
 

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -148,6 +148,10 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     return YES;
 }
 
+- (BOOL)prefersHomeIndicatorAutoHidden {
+    return YES;
+}
+
 - (UIStatusBarAnimation)preferredStatusBarUpdateAnimation {
     return UIStatusBarAnimationFade;
 }


### PR DESCRIPTION
<!--
Thanks for contributing!

Please open pull requests against the `develop` branch, and add a relevant note to the `develop` section of the CHANGELOG [0] as part of your pull request.

[0]: https://github.com/NYTimes/NYTPhotoViewer/blob/develop/CHANGELOG.md#develop
-->
## What it does

Respects the safe area layout guide for the caption view and the top items (https://github.com/NYTimes/NYTPhotoViewer/issues/246).

Thanks so much to @matthiaskmt for submitting this PR: https://github.com/NYTimes/NYTPhotoViewer/pull/247. We decided to go a slightly different route by adding a delegate method `photosViewController:captionViewRespectsSafeAreaForPhoto:` to allow the client to choose if they want their caption view to adhere to the safe area insets. If a caption has a background view the client may want those colors/gradients/etc. to extend to the edges of the screen.
