### PR TITLE
Fixed gradientLayer for safe area.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes for users of the library currently on `develop`:
     - A data source no longer has to handle out-of-bounds indexes ([#227](https://github.com/NYTimes/NYTPhotoViewer/pull/227))
     - The data source is not retained ([#227](https://github.com/NYTimes/NYTPhotoViewer/pull/227))
 - Respect safe areas for iOS 11 support
+- Fixed gradientLayer (which is inside NYTPhotoCaptionView) position for views that respects safe area (Can be related to [#257](https://github.com/NYTimes/NYTPhotoViewer/issues/257))
 
 ## [1.2.0](https://github.com/NYTimes/NYTPhotoViewer/releases/tag/1.2.0)
 

--- a/NYTPhotoViewer.xcodeproj/project.pbxproj
+++ b/NYTPhotoViewer.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		11FBDAFD1C877D9A00018169 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 11FBDAFB1C877D9A00018169 /* LaunchScreen.xib */; };
 		11FBDAFE1C877F5500018169 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 111084781C876A2B00699670 /* Assets.xcassets */; };
 		11FBDAFF1C877F8000018169 /* giphy.gif in Resources */ = {isa = PBXBuildFile; fileRef = 111084851C876B0400699670 /* giphy.gif */; };
+		370F9D1920909E1D00E1F090 /* NYTPhotoCaptionViewRespectsSafeArea.h in Headers */ = {isa = PBXBuildFile; fileRef = 370F9D1220909E1D00E1F090 /* NYTPhotoCaptionViewRespectsSafeArea.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		370F9D1A20909E1D00E1F090 /* NYTPhotoCaptionViewRespectsSafeArea.h in Headers */ = {isa = PBXBuildFile; fileRef = 370F9D1220909E1D00E1F090 /* NYTPhotoCaptionViewRespectsSafeArea.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9371A73C1E438B9C00A8F2EF /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371A73B1E438B9C00A8F2EF /* Photo.swift */; };
 		9371A7441E438BCE00A8F2EF /* PhotoBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371A7431E438BCE00A8F2EF /* PhotoBox.swift */; };
 		9371A7461E43D61E00A8F2EF /* PhotoViewerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371A7451E43D61E00A8F2EF /* PhotoViewerCoordinator.swift */; };
@@ -293,6 +295,7 @@
 		11FBDAEA1C877BD600018169 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		11FBDAF01C877C8B00018169 /* PhotosProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotosProvider.swift; sourceTree = "<group>"; };
 		11FBDAFC1C877D9A00018169 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		370F9D1220909E1D00E1F090 /* NYTPhotoCaptionViewRespectsSafeArea.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYTPhotoCaptionViewRespectsSafeArea.h; sourceTree = "<group>"; };
 		9371A73B1E438B9C00A8F2EF /* Photo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
 		9371A7431E438BCE00A8F2EF /* PhotoBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotoBox.swift; sourceTree = "<group>"; };
 		9371A7451E43D61E00A8F2EF /* PhotoViewerCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotoViewerCoordinator.swift; sourceTree = "<group>"; };
@@ -422,6 +425,7 @@
 			children = (
 				111084461C87682300699670 /* NYTPhoto.h */,
 				111084471C87682300699670 /* NYTPhotoCaptionViewLayoutWidthHinting.h */,
+				370F9D1220909E1D00E1F090 /* NYTPhotoCaptionViewRespectsSafeArea.h */,
 				111084481C87682300699670 /* NYTPhotoContainer.h */,
 				111084491C87682300699670 /* NYTPhotoViewerDataSource.h */,
 			);
@@ -527,6 +531,7 @@
 				1110845C1C87682300699670 /* NYTScalingImageView.h in Headers */,
 				111084521C87682300699670 /* NYTPhotosOverlayView.h in Headers */,
 				111084561C87682300699670 /* NYTPhotoTransitionAnimator.h in Headers */,
+				370F9D1920909E1D00E1F090 /* NYTPhotoCaptionViewRespectsSafeArea.h in Headers */,
 				93F45B181E3BB5610093DB93 /* NYTPhotoViewerSinglePhotoDataSource.h in Headers */,
 				111084581C87682300699670 /* NYTPhotoTransitionController.h in Headers */,
 				1110845F1C87682300699670 /* NYTPhotoCaptionViewLayoutWidthHinting.h in Headers */,
@@ -550,6 +555,7 @@
 				11FBDA901C87753200018169 /* NYTPhotoViewerArrayDataSource.h in Headers */,
 				11FBDA9F1C87753200018169 /* NYTPhotoCaptionViewLayoutWidthHinting.h in Headers */,
 				11FBDA941C87753200018169 /* NYTPhotosViewController.h in Headers */,
+				370F9D1A20909E1D00E1F090 /* NYTPhotoCaptionViewRespectsSafeArea.h in Headers */,
 				93F45B191E3BB5610093DB93 /* NYTPhotoViewerSinglePhotoDataSource.h in Headers */,
 				11FBDAA61C87768B00018169 /* NYTPhotoViewerCore.h in Headers */,
 				11FBDA9E1C87753200018169 /* NYTPhoto.h in Headers */,

--- a/NYTPhotoViewer/NYTPhotoCaptionView.h
+++ b/NYTPhotoViewer/NYTPhotoCaptionView.h
@@ -8,6 +8,7 @@
 
 @import UIKit;
 #import "NYTPhotoCaptionViewLayoutWidthHinting.h"
+#import "NYTPhotoCaptionViewRespectsSafeArea.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,7 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  This is used by default when no custom caption view is provided.
  */
-@interface NYTPhotoCaptionView : UIView <NYTPhotoCaptionViewLayoutWidthHinting>
+@interface NYTPhotoCaptionView : UIView <NYTPhotoCaptionViewLayoutWidthHinting, NYTPhotoCaptionViewRespectsSafeArea>
+
+@property (nonatomic) BOOL respectsSafeArea;
 
 /**
  *  Designated initializer that takes all the caption attributed strings as arguments.

--- a/NYTPhotoViewer/NYTPhotoCaptionView.m
+++ b/NYTPhotoViewer/NYTPhotoCaptionView.m
@@ -59,7 +59,7 @@ static const CGFloat NYTPhotoCaptionViewVerticalMargin = 7.0;
     [super layoutSubviews];
 
     void (^updateGradientFrame)() = ^{
-        self.gradientLayer.frame = self.layer.bounds;
+        [self updateGradientLayerFrame];
     };
 
     updateGradientFrame();
@@ -130,9 +130,23 @@ static const CGFloat NYTPhotoCaptionViewVerticalMargin = 7.0;
 
 - (void)setupGradient {
     self.gradientLayer = [CAGradientLayer layer];
-    self.gradientLayer.frame = self.layer.bounds;
+    [self updateGradientLayerFrame];
     self.gradientLayer.colors = [NSArray arrayWithObjects:(id)[UIColor clearColor].CGColor, (id)[[UIColor blackColor] colorWithAlphaComponent:0.85].CGColor, nil];
+
     [self.layer insertSublayer:self.gradientLayer atIndex:0];
+}
+
+- (void)updateGradientLayerFrame {
+    if (self.respectsSafeArea) {
+        UIEdgeInsets safeAreaInsets = [[UIApplication sharedApplication] keyWindow].safeAreaInsets;
+        CGRect selfBounds = self.layer.bounds;
+        self.gradientLayer.frame = CGRectMake(selfBounds.origin.x - safeAreaInsets.left,
+                                              selfBounds.origin.y + safeAreaInsets.bottom,
+                                              selfBounds.size.width + safeAreaInsets.left + safeAreaInsets.right,
+                                              selfBounds.size.height + safeAreaInsets.bottom);
+    } else {
+        self.gradientLayer.frame = self.layer.bounds;
+    }
 }
 
 - (void)updateTextViewAttributedText {

--- a/NYTPhotoViewer/NYTPhotosOverlayView.m
+++ b/NYTPhotoViewer/NYTPhotosOverlayView.m
@@ -8,6 +8,7 @@
 
 #import "NYTPhotosOverlayView.h"
 #import "NYTPhotoCaptionViewLayoutWidthHinting.h"
+#import "NYTPhotoCaptionViewRespectsSafeArea.h"
 
 @interface UIView (NYTSafeArea)
 
@@ -104,6 +105,10 @@
     
     self.captionView.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:self.captionView];
+    
+    if ([captionView conformsToProtocol:@protocol(NYTPhotoCaptionViewRespectsSafeArea)]) {
+        [(id<NYTPhotoCaptionViewRespectsSafeArea>)captionView setRespectsSafeArea:self.captionViewRespectsSafeArea];
+    }
 
     if ([self respondsToSelector:@selector(safeAreaLayoutGuide)] && self.captionViewRespectsSafeArea) {
         NSLayoutConstraint *bottomConstraint = [self.captionView.bottomAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.bottomAnchor];

--- a/NYTPhotoViewer/Protocols/NYTPhotoCaptionViewRespectsSafeArea.h
+++ b/NYTPhotoViewer/Protocols/NYTPhotoCaptionViewRespectsSafeArea.h
@@ -1,0 +1,20 @@
+//
+//  NYTPhotoCaptionViewRespectsSafeArea.h
+//  NYTPhotoViewer
+//
+//  Created by Anton Popovichenko on 25.04.2018.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ *  Allows a view to opt-in to know about using safe area.
+ */
+@protocol NYTPhotoCaptionViewRespectsSafeArea <NSObject>
+
+/**
+ * Stores value from NYTPhotosOverlayView.captionViewRespectsSafeArea.
+ */
+@property (nonatomic) BOOL respectsSafeArea;
+
+@end


### PR DESCRIPTION
Fixed gradientLayer (which is inside NYTPhotoCaptionView) position for views that respects safe area.

Problem sample:
![alt text](https://preview.ibb.co/kDDyKH/2018_04_25_14_52_55.png)