### PR TITLE
Set accessibilityIgnoresInvertColors on image views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes for users of the library currently on `develop`:
 - Fixed some tests, added tests for NYTPhotoViewerSinglePhotoDataSource
 - Fixed a strict warning and a subscripting bug in NYTPhotoViewerArrayDataSource.m
 - Added support for interstitial views
+- Set `accessibilityIgnoresInvertColors = true` on image views
 
 ## [2.0.0](https://github.com/NYTimes/NYTPhotoViewer/releases/tag/2.0.0)
 

--- a/Example-Swift/ViewController.swift
+++ b/Example-Swift/ViewController.swift
@@ -32,6 +32,10 @@ final class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        if #available(iOS 11.0, *) {
+            imageButton?.accessibilityIgnoresInvertColors = true
+        }
+
         let buttonImage = UIImage(named: ReferencePhotoName)
         imageButton?.setBackgroundImage(buttonImage, for: UIControlState())
     }

--- a/Example/NYTViewController.m
+++ b/Example/NYTViewController.m
@@ -30,6 +30,14 @@ typedef NS_ENUM(NSUInteger, NYTViewControllerPhotoIndex) {
 
 @implementation NYTViewController
 
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    if (@available(iOS 11.0, *)) {
+        self.imageButton.accessibilityIgnoresInvertColors = YES;
+    }
+}
+
 - (IBAction)imageButtonTapped:(id)sender {
     self.dataSource = [self.class newTimesBuildingDataSource];
 

--- a/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
+++ b/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
@@ -120,6 +120,11 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
     if (!endingViewForAnimation) {
         endingViewForAnimation = [[self class] newAnimationViewFromView:self.endingView];
     }
+
+    if (@available(iOS 11.0, *)) {
+        startingViewForAnimation.accessibilityIgnoresInvertColors = YES;
+        endingViewForAnimation.accessibilityIgnoresInvertColors = YES;
+    }
     
     CGAffineTransform finalEndingViewTransform = self.endingView.transform;
 

--- a/NYTPhotoViewer/NYTScalingImageView.m
+++ b/NYTPhotoViewer/NYTScalingImageView.m
@@ -92,6 +92,9 @@
 #else
     self.imageView = [[UIImageView alloc] initWithImage:imageToUse];
 #endif
+    if (@available(iOS 11.0, *)) {
+        self.imageView.accessibilityIgnoresInvertColors = YES;
+    }
     [self updateImage:imageToUse imageData:imageData];
     
     [self addSubview:self.imageView];


### PR DESCRIPTION
In iOS 11 there was a new Accessibility Shortcut introduced: Smart Invert Colours. In the Settings.app on iOS it says:
> Smart Invert Colours reverses the colours of the display, except for images, media and some apps that use dark colour styles.
This does not just work without any code change, we have to set `accessibilityIgnoresInvertColors = true` on the views we don't want the colours to change.