### PR TITLE
fix NYTPhotoTransitionAnimator translation animation, when the target photo is gif and FLAnimatedImageView is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes for users of the library currently on `develop`:
 - Fixed some tests, added tests for NYTPhotoViewerSinglePhotoDataSource
 - Fixed a strict warning and a subscripting bug in NYTPhotoViewerArrayDataSource.m
 - Added support for interstitial views
+- Fix NYTPhotoTransitionAnimator translation animation, when the target photo is gif and FLAnimatedImageView is used.
 
 ## [2.0.0](https://github.com/NYTimes/NYTPhotoViewer/releases/tag/2.0.0)
 

--- a/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
+++ b/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
@@ -8,6 +8,11 @@
 
 #import "NYTPhotoTransitionAnimator.h"
 
+#ifdef ANIMATED_GIF_SUPPORT
+#import <FLAnimatedImage/FLAnimatedImage.h>
+#endif
+
+
 static const CGFloat NYTPhotoTransitionAnimatorDurationWithZooming = 0.5;
 static const CGFloat NYTPhotoTransitionAnimatorDurationWithoutZooming = 0.3;
 static const CGFloat NYTPhotoTransitionAnimatorBackgroundFadeDurationRatio = 4.0 / 9.0;
@@ -245,12 +250,34 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
         animationView.contentMode = view.contentMode;
         animationView.transform = view.transform;
     }
+#ifdef ANIMATED_GIF_SUPPORT
+    else if ([view isKindOfClass:[FLAnimatedImageView class]]) {
+        animationView = [self snapshotViewForFLAnimatedView:(FLAnimatedImageView *)view];
+    }
+#endif
     else {
         animationView = [view snapshotViewAfterScreenUpdates:YES];
     }
 
     return animationView;
 }
+
+#ifdef ANIMATED_GIF_SUPPORT
++ (UIView *)snapshotViewForFLAnimatedView:(FLAnimatedImageView *)imageView {
+    UIView *tarImageView = nil;
+    if (imageView.image) {
+        tarImageView = [[UIImageView  alloc] initWithImage:imageView.image];
+    } else if (imageView.animatedImage) {
+        tarImageView = [[UIImageView  alloc] initWithImage:imageView.currentFrame];
+    } else {
+        tarImageView = [imageView snapshotViewAfterScreenUpdates:YES];
+        return tarImageView;
+    }
+    
+    tarImageView.bounds = imageView.bounds;
+    return tarImageView;
+}
+#endif
 
 #pragma mark - UIViewControllerAnimatedTransitioning
 


### PR DESCRIPTION
When gif support is enabled and the image being showed is is gif,  and `photosViewController:referenceViewForPhoto:`  is implemented to support translation, methods `newAnimationViewFromView` of `FLAnimatedImageView` is not correct. This will lead to wrong animation.