### PR TITLE
[APP-2020] Up deployment target to 9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Changes for users of the library currently on `develop`:
 
+- Update deployment target to 9.0 from 8.0
+- Remove property `UIPopoverController *activityPopoverController` from `NYTPhotosViewController`
+
 ## [3.0.1](https://github.com/nytimes/NYTPhotoViewer/releases/tag/3.0.1)
 
 Changes for users of the library in 3.0.1:

--- a/NYTPhotoViewer.xcodeproj/project.pbxproj
+++ b/NYTPhotoViewer.xcodeproj/project.pbxproj
@@ -700,6 +700,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -1090,7 +1091,7 @@
 				);
 				INFOPLIST_FILE = NYTPhotoViewer/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.NYTimes.NYTPhotoViewer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1109,7 +1110,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "ANIMATED_GIF_SUPPORT=1";
 				INFOPLIST_FILE = NYTPhotoViewer/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.NYTimes.NYTPhotoViewer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1169,7 +1170,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = NYTPhotoViewer/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.NYTimes.NYTPhotoViewerCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1187,7 +1188,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = NYTPhotoViewer/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.NYTimes.NYTPhotoViewerCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -37,7 +37,6 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
 
 @property (nonatomic) UIPageViewController *pageViewController;
 @property (nonatomic) NYTPhotoTransitionController *transitionController;
-@property (nonatomic) UIPopoverController *activityPopoverController;
 
 @property (nonatomic) UIPanGestureRecognizer *panGestureRecognizer;
 @property (nonatomic) UITapGestureRecognizer *singleTapGestureRecognizer;

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pod 'NYTPhotoViewer'
 
 ## Requirements
 
-This library requires a deployment target of iOS 8.0 or greater.
+This library requires a deployment target of iOS 9.0 or greater.
 
 ## Changelog
 


### PR DESCRIPTION
## What This Does

- Update the deployment target which should make publishing the podspec work again.
- Removes a `UIPopoverViewController` property. 

## Related Info

[JIRA](https://jira.nyt.net/browse/APP-2020)