### PR TITLE
fix: podspec should use 9.0

### DIFF
--- a/NYTPhotoViewer.podspec
+++ b/NYTPhotoViewer.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'Apache 2.0' }
   s.source           = { :git => "https://github.com/NYTimes/NYTPhotoViewer.git", :tag => s.version.to_s }
 
-  s.platform     = :ios, '8.0'
+  s.platform     = :ios, '9.0'
   s.requires_arc = true
 
   s.subspec 'Core' do |ss|


### PR DESCRIPTION
<!--
Thanks for contributing!

Please open pull requests against the `develop` branch, and add a relevant note to the `develop` section of the CHANGELOG [0] as part of your pull request.

[0]: https://github.com/NYTimes/NYTPhotoViewer/blob/develop/CHANGELOG.md#develop
-->
