### PR TITLE
Fix gitmodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Carthage/Checkouts/FLAnimatedImage"]
-	path = Carthage/Checkouts/FLAnimatedImage
-	url = https://github.com/Flipboard/FLAnimatedImage.git
 [submodule "Carthage/Checkouts/ocmock"]
 	path = Carthage/Checkouts/ocmock
 	url = https://github.com/erikdoe/ocmock.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## `develop`
 
+Changes for users of the library currently on `develop`:
+
+- Removed `FLAnimatedImage` from .gitmodules.
+
 ## [4.0.0](https://github.com/nytimes/NYTPhotoViewer/releases/tag/4.0.0)
 
-Changes for users of the library currently on `develop`:
+Changes for users of the library in 4.0.0:
 
 - Update deployment target to 9.0 from 8.0
 - Remove property `UIPopoverController *activityPopoverController` from `NYTPhotosViewController`


### PR DESCRIPTION
When I run `carthage update NYTPhotoViewer`, I get the following error:  
```
Parse error: expected submodule commit SHA in output of task (ls-tree -z 4.0.0 Carthage/Checkouts/FLAnimatedImage) but encountered: 
```

Since FLAnimatedImage has been replaced, Removed from .gitmodule.