### PR TITLE
Capture fullscreen presentation context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes for users of the library currently on `develop`:
 
 - Removed `FLAnimatedImage` from .gitmodules.
+- Change `NYTPhotosViewController` to use fullscreen presentation by default, so it causes the presenting view to disappear behind it, i.e. to get `-viewWillDisappear:` and `-viewDidDisappear` called on it.
 
 ## [4.0.0](https://github.com/nytimes/NYTPhotoViewer/releases/tag/4.0.0)
 

--- a/NYTPhotoViewer/NYTPhotoDismissalInteractionController.m
+++ b/NYTPhotoViewer/NYTPhotoDismissalInteractionController.m
@@ -89,6 +89,14 @@ static const CGFloat NYTPhotoDismissalInteractionControllerReturnToCenterVelocit
             finalBackgroundAlpha = 0.0;
         }
     }
+    else {
+        // Interactive transition was canceled (i.e. the user changed their mind and decided not to finish the
+        // dismissal), so if we are presenting fullscreen, remove the presenting view controller's view.
+        if (self.transitionContext.presentationStyle == UIModalPresentationFullScreen) {
+            UIView *toView = [self.transitionContext viewForKey:UITransitionContextToViewKey];
+            [toView removeFromSuperview];
+        }
+    }
     
     if (!didAnimateUsingAnimator) {
         [UIView animateWithDuration:animationDuration delay:0 options:animationCurve animations:^{

--- a/NYTPhotoViewer/NYTPhotoDismissalInteractionController.m
+++ b/NYTPhotoViewer/NYTPhotoDismissalInteractionController.m
@@ -27,6 +27,16 @@ static const CGFloat NYTPhotoDismissalInteractionControllerReturnToCenterVelocit
     CGPoint translatedPanGesturePoint = [panGestureRecognizer translationInView:fromView];
     CGPoint newCenterPoint = CGPointMake(anchorPoint.x, anchorPoint.y + translatedPanGesturePoint.y);
     
+    UIView *toView = [self.transitionContext viewForKey:UITransitionContextToViewKey];
+    if (!toView.superview) {
+        UIViewController *toViewController = [self.transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+        toView.frame = [self.transitionContext finalFrameForViewController:toViewController];
+        if (![toView isDescendantOfView:self.transitionContext.containerView]) {
+            [self.transitionContext.containerView addSubview:toView];
+        }
+        [self.transitionContext.containerView bringSubviewToFront:fromView];
+    }
+
     // Pan the view on pace with the pan gesture.
     viewToPan.center = newCenterPoint;
     

--- a/NYTPhotoViewer/NYTPhotoDismissalInteractionController.m
+++ b/NYTPhotoViewer/NYTPhotoDismissalInteractionController.m
@@ -26,7 +26,10 @@ static const CGFloat NYTPhotoDismissalInteractionControllerReturnToCenterVelocit
     UIView *fromView = [self.transitionContext viewForKey:UITransitionContextFromViewKey];
     CGPoint translatedPanGesturePoint = [panGestureRecognizer translationInView:fromView];
     CGPoint newCenterPoint = CGPointMake(anchorPoint.x, anchorPoint.y + translatedPanGesturePoint.y);
-    
+
+    // If we are presenting fullscreen, the presenting view controller's view will have been removed from the view
+    // hierarchy when the presentation animation finished. We need to put it back in the view hierarchy in order for
+    // it to appear behind the interactive dismissal animation.
     UIView *toView = [self.transitionContext viewForKey:UITransitionContextToViewKey];
     if (!toView.superview) {
         UIViewController *toViewController = [self.transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -193,7 +193,7 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     _singleTapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didSingleTapWithGestureRecognizer:)];
 
     _transitionController = [[NYTPhotoTransitionController alloc] init];
-    self.modalPresentationStyle = UIModalPresentationCustom;
+    self.modalPresentationStyle = UIModalPresentationFullScreen;
     self.transitioningDelegate = _transitionController;
     self.modalPresentationCapturesStatusBarAppearance = YES;
 


### PR DESCRIPTION
Change `NYTPhotosViewController` to use fullscreen presentation by default, so it causes the presenting view to disappear behind it, i.e. to get `-viewWillDisappear:` and `-viewDidDisappear:` called on it.

Once this change was made, I noticed that the interactive dismissal transition no longer worked, because the presenting VC's view wasn't put back in the view hierarchy until the end of the transition. So, most of this PR consists of adding the presenting VC's view back at the start of the interactive dismissal, and removing it again if the interactive dismissal is canceled.

**Before:** when the photos VC is fullscreen, the presenting view controller is still in the view hierarchy:

<img width="789" alt="before" src="https://user-images.githubusercontent.com/464574/77651020-949c0900-6f42-11ea-99f0-429e56a0a5d8.png">

**After:** the presenting VC is no longer in the view hierarchy, even after an interactive dismissal is canceled.

<img width="870" alt="after" src="https://user-images.githubusercontent.com/464574/77651060-a1b8f800-6f42-11ea-8e66-5a4f58759b52.png">

Note: I tried to write unit tests for this, but ran into many issues with OCMock, my own "spy" view controller, and general VC lifecycle events in tests. Happy to discuss with anyone who wants to try writing a test.