### PR TITLE
Fix unbalanced appearance transitions calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes for users of the library currently on `develop`:
 
 - Removed `FLAnimatedImage` from .gitmodules.
+- Fix unbalanced calls to begin/end appearance transitions.
 
 ## [4.0.0](https://github.com/nytimes/NYTPhotoViewer/releases/tag/4.0.0)
 

--- a/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
+++ b/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
@@ -266,8 +266,12 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
 
 #pragma mark - UIViewControllerAnimatedTransitioning
 - (void)animationEnded:(BOOL)transitionCompleted {
-    [self.toViewController endAppearanceTransition];
-    [self.fromViewController endAppearanceTransition];
+    if (self.toViewController.parentViewController) {
+        [self.toViewController endAppearanceTransition];
+    }
+    if (self.fromViewController.parentViewController) {
+        [self.fromViewController endAppearanceTransition];
+    }
 }
 
 - (NSTimeInterval)transitionDuration:(id <UIViewControllerContextTransitioning>)transitionContext {


### PR DESCRIPTION
This addresses an issue in the Example app where presenting `NYTPhotosViewController` logs the following warning:
```
Unbalanced calls to begin/end appearance transitions for <NYTPhotosViewController>.
Unbalanced calls to begin/end appearance transitions for <NYTViewController>.
```
