### PR TITLE
Modify comment parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes for users of the library currently on `develop`:
 
 - Removed `FLAnimatedImage` from .gitmodules.
 - Change `NYTPhotosViewController` to use fullscreen presentation by default, so it causes the presenting view to disappear behind it, i.e. to get `-viewWillDisappear:` and `-viewDidDisappear` called on it.
+- Modified comment parameter in `NYTPhotosViewController` and `NYTPhotoViewerSinglePhotoDataSource` to match parameter in signature. Removes compilation warning.
 
 ## [4.0.0](https://github.com/nytimes/NYTPhotoViewer/releases/tag/4.0.0)
 

--- a/NYTPhotoViewer/NYTPhotoViewerSinglePhotoDataSource.h
+++ b/NYTPhotoViewer/NYTPhotoViewerSinglePhotoDataSource.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  The designated initializer that takes and stores a single photo.
  *
- *  @param photos An object conforming to the `NYTPhoto` protocol.
+ *  @param photo An object conforming to the `NYTPhoto` protocol.
  *
  *  @return A fully initialized data source.
  */

--- a/NYTPhotoViewer/NYTPhotosViewController.h
+++ b/NYTPhotoViewer/NYTPhotosViewController.h
@@ -146,7 +146,7 @@ extern NSString * const NYTPhotosViewControllerDidDismissNotification;
  *
  *  This method has no effect if the given index is out of bounds in the data source.
  *
- *  @param photo The index of the photo which changed in the data source.
+ *  @param photoIndex The index of the photo which changed in the data source.
  */
 - (void)updatePhotoAtIndex:(NSInteger)photoIndex;
 


### PR DESCRIPTION
Non functional change. Modified comment parameter in 'NYTPhotosViewController' and 'NYTPhotoViewerSinglePhotoDataSource' to match parameter in signature. Removes compilation warning.
