### PR TITLE
Modify PINRemoteImage dependency

### DIFF
--- a/NYTPhotoViewer.podspec
+++ b/NYTPhotoViewer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "NYTPhotoViewer"
-  s.version          = "5.0.2"
+  s.version          = "5.0.3"
 
   s.description      = <<-DESC
                        NYTPhotoViewer is a slideshow and image viewer that includes double tap to zoom, captions, support for multiple images, interactive flick to dismiss, animated zooming presentation, and more.
@@ -25,7 +25,8 @@ Pod::Spec.new do |s|
     ss.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ANIMATED_GIF_SUPPORT=1'}
 
     ss.dependency 'NYTPhotoViewer/Core'
-    ss.dependency 'PINRemoteImage', '~> 3.0.0'
+    ss.dependency 'PINRemoteImage/iOS', '~> 3.0.0'
+    ss.dependency 'PINRemoteImage/PINCache'
   end
 
 end


### PR DESCRIPTION
Be more explicit about the various subspecs that are needed from PINRemoteImage. This is being done to match [Texture 3.0's podspec](https://github.com/TextureGroup/Texture/blob/9ef97f49657e6e690bb222ef4634bbdcc453c3c2/Texture.podspec#L41) and help address transitive dependency warnings when using Texture 3.0.
