### PR TITLE
Bumps PINCache to latest 3.0.1

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "erikdoe/ocmock" "v3.6"
-github "pinterest/PINCache" "3.0.1-beta.8"
+github "pinterest/PINCache" "3.0.1"
 github "pinterest/PINOperation" "1.1.2"
 github "pinterest/PINRemoteImage" "3.0.0"


### PR DESCRIPTION
<!--
Thanks for contributing!

Please open pull requests against the `develop` branch, and add a relevant note to the `develop` section of the CHANGELOG [0] as part of your pull request.

[0]: https://github.com/NYTimes/NYTPhotoViewer/blob/develop/CHANGELOG.md#develop
-->

Fixes https://github.com/nytimes/NYTPhotoViewer/issues/321
