### PR TITLE
Fix #341 - restore support for animated gifs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ ocunit.xml
 Examples/vendor/bundle/
 .bundle/
 Pods/
+.build/

--- a/NYTPhotoViewer/NYTPhotoViewController.m
+++ b/NYTPhotoViewer/NYTPhotoViewController.m
@@ -11,8 +11,13 @@
 #import "NYTScalingImageView.h"
 
 #ifdef ANIMATED_GIF_SUPPORT
-#import <PINRemoteImage/PINRemoteImage.h>
-#import <PINRemoteImage/PINAnimatedImageView.h>
+#if SWIFT_PACKAGE
+  #import "PINRemoteImage.h"
+  #import "PINAnimatedImageView.h"
+#else
+  #import <PINRemoteImage/PINRemoteImage.h>
+  #import <PINRemoteImage/PINAnimatedImageView.h>
+#endif
 #endif
 
 NSString * const NYTPhotoViewControllerPhotoImageUpdatedNotification = @"NYTPhotoViewControllerPhotoImageUpdatedNotification";

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -19,8 +19,13 @@
 #import "NSBundle+NYTPhotoViewer.h"
 
 #ifdef ANIMATED_GIF_SUPPORT
-#import <PINRemoteImage/PINRemoteImage.h>
-#import <PINRemoteImage/PINAnimatedImageView.h>
+#if SWIFT_PACKAGE
+  #import "PINRemoteImage.h"
+  #import "PINAnimatedImageView.h"
+#else
+  #import <PINRemoteImage/PINRemoteImage.h>
+  #import <PINRemoteImage/PINAnimatedImageView.h>
+#endif
 #endif
 
 NSString * const NYTPhotosViewControllerDidNavigateToPhotoNotification = @"NYTPhotosViewControllerDidNavigateToPhotoNotification";

--- a/NYTPhotoViewer/NYTScalingImageView.m
+++ b/NYTPhotoViewer/NYTScalingImageView.m
@@ -11,8 +11,13 @@
 #import "tgmath.h"
 
 #ifdef ANIMATED_GIF_SUPPORT
-#import <PINRemoteImage/PINRemoteImage.h>
-#import <PINRemoteImage/PINAnimatedImageView.h>
+#if SWIFT_PACKAGE
+  #import "PINRemoteImage.h"
+  #import "PINAnimatedImageView.h"
+#else
+  #import <PINRemoteImage/PINRemoteImage.h>
+  #import <PINRemoteImage/PINAnimatedImageView.h>
+#endif
 #endif
 
 @interface NYTScalingImageView ()

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "libwebp",
+        "repositoryURL": "https://github.com/SDWebImage/libwebp-Xcode",
+        "state": {
+          "branch": null,
+          "revision": "86c1b5d567ed548da861486b54e1f8f068a3cef7",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "PINCache",
+        "repositoryURL": "https://github.com/pinterest/PINCache.git",
+        "state": {
+          "branch": null,
+          "revision": "875c654984fb52b47ca65ae70d24852b0003ccd9",
+          "version": "3.0.3"
+        }
+      },
+      {
+        "package": "PINOperation",
+        "repositoryURL": "https://github.com/pinterest/PINOperation.git",
+        "state": {
+          "branch": null,
+          "revision": "44d8ca154a4e75a028a5548c31ff3a53b90cef15",
+          "version": "1.2.1"
+        }
+      },
+      {
+        "package": "PINRemoteImage",
+        "repositoryURL": "https://github.com/pinterest/PINRemoteImage.git",
+        "state": {
+          "branch": null,
+          "revision": "611d8ab1c6937bcdfd9d59a967716b0370a332be",
+          "version": "3.0.3"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -19,11 +19,9 @@ let package = Package(
             name: "NYTPhotoViewerGIF",
             dependencies: ["PINRemoteImage"],
             path: "NYTPhotoViewer",
-            cSettings: [ "-DANIMATED_GIF_SUPPORT" ],
-        )
-        .target(
-            name: "NYTPhotoViewer",
-            path: "NYTPhotoViewer"),
+            cSettings: [
+              .define("ANIMATED_GIF_SUPPORT", to: "1")
+            ]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,9 @@ let package = Package(
         .target(
             name: "NYTPhotoViewerGIF",
             dependencies: ["PINRemoteImage"],
-            path: "NYTPhotoViewer"),
-            cSettings: [ "-DANIMATED_GIF_SUPPORT"],
+            path: "NYTPhotoViewer",
+            cSettings: [ "-DANIMATED_GIF_SUPPORT" ],
+        )
         .target(
             name: "NYTPhotoViewer",
             path: "NYTPhotoViewer"),

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
         .target(
             name: "NYTPhotoViewerGIF",
             dependencies: ["PINRemoteImage"],
-            cSettings: [ "-DANIMATED_GIF_SUPPORT"],
             path: "NYTPhotoViewer"),
+            cSettings: [ "-DANIMATED_GIF_SUPPORT"],
         .target(
             name: "NYTPhotoViewer",
             path: "NYTPhotoViewer"),

--- a/Package.swift
+++ b/Package.swift
@@ -9,16 +9,21 @@ let package = Package(
     products: [
         .library(
             name: "NYTPhotoViewer",
-            targets: ["NYTPhotoViewerGIF"]),
+            targets: ["NYTPhotoViewer", "NYTPhotoViewerGIF"]
+            ),
     ],
     dependencies: [
         .package(url: "https://github.com/pinterest/PINRemoteImage.git", from: "3.0.1")
     ],
     targets: [
         .target(
+            name: "NYTPhotoViewer",
+            path: "NYTPhotoViewer"
+        ),
+        .target(
             name: "NYTPhotoViewerGIF",
             dependencies: ["PINRemoteImage"],
-            path: "NYTPhotoViewer",
+            path: "SourceSymLink",
             cSettings: [
               .define("ANIMATED_GIF_SUPPORT", to: "1")
             ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,15 +9,20 @@ let package = Package(
     products: [
         .library(
             name: "NYTPhotoViewer",
-            targets: ["NYTPhotoViewer"]),
+            targets: ["NYTPhotoViewerGIF"]),
     ],
     dependencies: [
         .package(url: "https://github.com/pinterest/PINRemoteImage.git", from: "3.0.1")
     ],
     targets: [
         .target(
-            name: "NYTPhotoViewer",
+            name: "NYTPhotoViewerGIF",
             dependencies: ["PINRemoteImage"],
+            cSettings: [ "-DANIMATED_GIF_SUPPORT"],
             path: "NYTPhotoViewer"),
+        .target(
+            name: "NYTPhotoViewer",
+            path: "NYTPhotoViewer"),
+        )
     ]
 )

--- a/SourceSymLink
+++ b/SourceSymLink
@@ -1,0 +1,1 @@
+./NYTPhotoViewer


### PR DESCRIPTION
#### Added 2nd Target 

(avoiding the '[target 2] has source overlapping sources' problem with a symlink)

```swift
    targets: [
        .target(
            name: "NYTPhotoViewer",
            path: "NYTPhotoViewer"
        ),
        .target(
            name: "NYTPhotoViewerGIF",
            dependencies: ["PINRemoteImage"],
            path: "SourceSymLink",
            cSettings: [
              .define("ANIMATED_GIF_SUPPORT", to: "1")
            ]
        )
    ]
```
####  Tweaked imports in 3 files by changing

```objc
#import <PINRemoteImage/FOO.h>
```

to
```objc
#if SWIFT_PACKAGE
  #import "FOO.h"
#else
  #import <PINRemoteImage/FOO.h>
#endif
```
