### PR TITLE
Bugfixes to use package in cooking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ## `develop`
 
 Changes for users of the library currently on `develop`:
+- fixed caption overlay placement
+- fixed overlay view buttons tint color
+- added summary to share
+
+## [5.0.6](https://github.com/nytimes/NYTPhotoViewer/releases/tag/5.0.6)
+
+Changes for users of the library in 5.0.6:
+
 - support Swift Package Manager (thanks @mattpolzin!)
 - fixed a NaN when setting `zoomScale` in `NYTScalingImageView` when `ANIMATED_GIF_SUPPORT=1`
 

--- a/NYTPhotoViewer/NYTPhotoCaptionView.m
+++ b/NYTPhotoViewer/NYTPhotoCaptionView.m
@@ -59,7 +59,18 @@ static const CGFloat NYTPhotoCaptionViewVerticalMargin = 7.0;
     [super layoutSubviews];
 
     void (^updateGradientFrame)(void) = ^{
-        self.gradientLayer.frame = self.layer.bounds;
+        if (@available(iOS 11.0, *)) {
+            UIEdgeInsets safeAreaInsets = [[UIApplication sharedApplication] keyWindow].safeAreaInsets;
+            CGRect selfBounds = self.layer.bounds;
+            self.gradientLayer.frame = CGRectMake(
+                                                  selfBounds.origin.x - safeAreaInsets.left,
+                                                  selfBounds.origin.y + safeAreaInsets.bottom,
+                                                  selfBounds.size.width + safeAreaInsets.left + safeAreaInsets.right,
+                                                  selfBounds.size.height + safeAreaInsets.bottom
+                                                  );
+        } else {
+            self.gradientLayer.frame = self.layer.bounds;
+        }
     };
 
     updateGradientFrame();

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -206,7 +206,9 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
         NYTPhotosOverlayView *v = [[NYTPhotosOverlayView alloc] initWithFrame:CGRectZero];
         v.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"NYTPhotoViewerCloseButtonX" inBundle:[NSBundle nyt_photoViewerResourceBundle] compatibleWithTraitCollection:nil] landscapeImagePhone:[UIImage imageNamed:@"NYTPhotoViewerCloseButtonXLandscape" inBundle:[NSBundle nyt_photoViewerResourceBundle] compatibleWithTraitCollection:nil] style:UIBarButtonItemStylePlain target:self action:@selector(doneButtonTapped:)];
         v.leftBarButtonItem.imageInsets = NYTPhotosViewControllerCloseButtonImageInsets;
+        v.leftBarButtonItem.tintColor = [UIColor whiteColor];
         v.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(actionButtonTapped:)];
+        v.rightBarButtonItem.tintColor = [UIColor whiteColor];
         v;
     });
 

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -298,7 +298,8 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     
     if (!clientDidHandle && (self.currentlyDisplayedPhoto.image || self.currentlyDisplayedPhoto.imageData)) {
         UIImage *image = self.currentlyDisplayedPhoto.image ? self.currentlyDisplayedPhoto.image : [UIImage imageWithData:self.currentlyDisplayedPhoto.imageData];
-        UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:@[image] applicationActivities:nil];
+        NSString *summary = self.currentlyDisplayedPhoto.attributedCaptionSummary.string;
+        UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:@[summary, image] applicationActivities:nil];
         activityViewController.popoverPresentationController.barButtonItem = sender;
         activityViewController.completionWithItemsHandler = ^(NSString * __nullable activityType, BOOL completed, NSArray * __nullable returnedItems, NSError * __nullable activityError) {
             if (completed && [self.delegate respondsToSelector:@selector(photosViewController:actionCompletedWithActivityType:)]) {


### PR DESCRIPTION
Bugfixes to use package in NYT Cooking
- fixed caption overlay placement
- fixed overlay view buttons tint color
- added summary to share

Attached screenshots of current issues:

|Bug_1|Bug_2|Bug_3|
|---|---|---|
|![1](https://user-images.githubusercontent.com/106048886/196735262-789b78f6-81d2-439b-b70f-67d59ccf8d0d.PNG)|![2](https://user-images.githubusercontent.com/106048886/196735261-c9f497b6-c203-45bb-a143-2e072fb65865.PNG)|![3](https://user-images.githubusercontent.com/106048886/196735258-1f566bbf-8cdc-4fa4-ada0-6120703e87d2.jpeg)
