### PR TITLE
Bugfixes to use package in cooking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+Changes for users of the library currently on `5.0.8`:
+- using metadata to add summary to share activity
+
 ## [5.0.7](https://github.com/nytimes/NYTPhotoViewer/releases/tag/5.0.7)
 
 Changes for users of the library currently on `5.0.7`:

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -671,11 +671,8 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
 /// called to fetch LinkPresentation metadata for the activity item. iOS 13.0
 - (LPLinkMetadata *)activityViewControllerLinkMetadata:(UIActivityViewController *)activityViewController API_AVAILABLE(ios(13.0))
 {
-    UIImage * icon = [UIImage imageNamed: @"AppIcon"];
-    NSItemProvider * iconProvider = [[NSItemProvider alloc] initWithObject:icon];
     LPLinkMetadata * metaData = [[LPLinkMetadata alloc] init];
     metaData.title = self.currentlyDisplayedPhoto.attributedCaptionSummary.string;
-    metaData.iconProvider = iconProvider;
     return metaData;
 }
 


### PR DESCRIPTION
### Background
In version 5.0.7 was introduced image summary as part of the share activity information. The approach used was to share a text with the summary and the image. This introduced a bug removing the app icon from the share sheet.

### Solution
This PR uses a different approach (using UIActivityItemSource protocol to pass image metadata) to still show the image summary when sharing and fixing the above described bug. 
### Screenshots
|Bug|Fix|
|---|---|
|<img width="375" alt="bug-with-share" src="https://user-images.githubusercontent.com/106048886/198070329-5f5d75bb-4237-4872-8749-3a66e5a38225.png">|<img width="396" alt="fix-share" src="https://user-images.githubusercontent.com/106048886/198070464-d185e8f8-9e85-4d6e-812c-d9f671287aae.png">|



