### PR TITLE
Remove obsolete badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # NYTPhotoViewer
 
-[![Platform](http://cocoapod-badges.herokuapp.com/p/NYTPhotoViewer/badge.png)](http://cocoadocs.org/docsets/NYTPhotoViewer)
-[![Version](http://cocoapod-badges.herokuapp.com/v/NYTPhotoViewer/badge.png)](http://cocoadocs.org/docsets/NYTPhotoViewer)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 NYTPhotoViewer is a slideshow and image viewer that includes double-tap to zoom, captions, support for multiple images, interactive flick to dismiss, animated zooming presentation, and more.


### PR DESCRIPTION
Cocoadocs is no more.

Its [GitHub page](https://github.com/CocoaPods/cocoadocs.org) says it was deprecated in 2015 and now has [a replacement](http://blog.cocoapods.org/CocoaPods-Metadata-Service/) for the CocoaPods-specific infrastructure. But I don't know if we need to replace it with anything.